### PR TITLE
Fetch mgi data

### DIFF
--- a/luigi/databases/data.py
+++ b/luigi/databases/data.py
@@ -100,6 +100,32 @@ class SecondaryStructure(object):
 
 
 @attr.s(frozen=True)
+class Reference(object):
+    """
+    This stores the data for a reference that will be written to out to csv
+    files.
+    """
+
+    accession = attr.ib(validator=is_a(basestring))
+    authors = attr.ib(validator=is_a(basestring))
+    location = attr.ib(validator=is_a(basestring))
+    title = attr.ib(validator=is_a(basestring))
+    pmid = attr.ib(validator=is_a(int))
+    doi = attr.ib(validator=is_a(basestring))
+
+    def md5(self):
+        """
+        Computes the MD5 hash of the reference.
+        """
+
+        return md5(''.join([
+            self.authors,
+            self.location,
+            self.title
+        ]))
+
+
+@attr.s(frozen=True)
 class Entry(object):
     """
     This represents an RNAcentral entry from GtRNAdb that we will write out for

--- a/luigi/databases/data.py
+++ b/luigi/databases/data.py
@@ -57,12 +57,15 @@ def possibly_empty(instance_type, **kwargs):
 
 @attr.s(frozen=True)
 class Exon(object):
+    chromosome = attr.ib(validator=is_a(basestring))
     primary_start = attr.ib(validator=is_a(int))
     primary_end = attr.ib(validator=is_a(int))
-    complement = attr.ib(validator=is_a(bool))
+    complement = optionally(bool)
 
     @property
     def strand(self):
+        if self.complement is None:
+            return None
         if self.complement:
             return -1
         return 1

--- a/luigi/mgi.py
+++ b/luigi/mgi.py
@@ -1,0 +1,242 @@
+# -*- coding: utf-8 -*-
+
+"""
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import csv
+
+import attr
+from attr.validators import instance_of as is_a
+
+from databases.data import optionally
+from databases.data import Exon
+
+RNA_TYPE_MAPPING = {
+    "gene": None,
+    "BAC/YAC end": None,
+    "DNA segment": None,
+    "RNase MRP RNA gene": "RNase_MRP_RNA",
+    "RNase P RNA gene": "RNase_P_RNA",
+    "SRP RNA gene": "SRP_RNA",
+    "antisense lncRNA gene": "lncRNA",
+    "chromosomal deletion": None,
+    "complex/cluster/region": None,
+    "endogenous retroviral region": None,
+    "gene segment": None,
+    "heritable phenotypic marker": None,
+    "intronic lncRNA gene": "lncRNA",
+    "lincRNA gene": "lncRNA",
+    "lncRNA gene": "lncRNA",
+    "miRNA gene": "miRNA",
+    "minisatellite": None,
+    "non-coding RNA gene": "ncRNA",
+    "other genome feature": None,
+    "polymorphic pseudogene": None,
+    "promoter": None,
+    "protein coding gene": None,
+    "pseudogene": None,
+    "pseudogenic gene segment": None,
+    "pseudogenic region": None,
+    "rRNA gene": "rRNA",
+    "retrotransposon": None,
+    "ribozyme gene": "ribozyme",
+    "scRNA gene": "scRNA",
+    "snRNA gene": "snRNA",
+    "snoRNA gene": "snoRNA",
+    "tRNA gene": "tRNA",
+    "telomerase RNA gene": "ncRNA",
+    "transgene": None,
+    "unclassified cytogenetic marker": None,
+    "unclassified gene": None,
+    "unclassified non-coding RNA gene": "ncRNA",
+    "unclassified other genome feature": None,
+}
+
+
+def accession(data):
+    """
+    Get the accession for the given data.
+    """
+    return data['mgi_marker_accession_id']
+
+
+def infer_rna_type(data):
+    """
+    Determine the rna_type of the given entry. If the entry is not RNA then
+    None will be returned.
+    """
+    base = data['feature_type']
+    return RNA_TYPE_MAPPING[base]
+
+
+def name(data):
+    return data['marker_name']
+
+
+def symbol(data):
+    return data['marker_symbol']
+
+
+def chromosome(data):
+    chrom = data['chromosome']
+    if chrom == 'UN':
+        return None
+    return chrom
+
+
+def start(data):
+    value = data['genome_coordinate_start']
+    if value:
+        return int(value)
+    return None
+
+
+def stop(data):
+    value = data['genome_coordinate_end']
+    if value:
+        return int(value)
+    return None
+
+
+def is_complement(data):
+    strand = data['strand']
+    if not strand:
+        return None
+    return strand == '-'
+
+
+def exon(data):
+    start_pos = start(data)
+    if not start_pos:
+        return None
+
+    return Exon(
+        chromosome=chromosome(data),
+        primary_start=start_pos,
+        primary_end=stop(data),
+        complement=is_complement(data),
+    )
+
+
+def split_ids(name, data):
+    if data[name]:
+        return data[name].split('|')
+    return []
+
+
+@attr.s()
+class RefSeqIds(object):
+    transcript_ids = attr.ib()
+    protein_ids = attr.ib()
+
+    @classmethod
+    def build(cls, data):
+        return cls(
+            transcript_ids=split_ids('refseq_transcript_ids', data),
+            protein_ids=split_ids('refseq_protein_ids', data),
+        )
+
+
+@attr.s()
+class VegaIds(object):
+    transcript_ids = attr.ib()
+    protein_ids = attr.ib()
+
+    @classmethod
+    def build(cls, data):
+        return cls(
+            transcript_ids=split_ids('vega_transcript_ids', data),
+            protein_ids=split_ids('vega_protein_ids', data),
+        )
+
+
+@attr.s()
+class EnsemblIds(object):
+    transcript_ids = attr.ib()
+    protein_ids = attr.ib()
+
+    @classmethod
+    def build(cls, data):
+        return cls(
+            transcript_ids=split_ids('ensembl_transcript_ids', data),
+            protein_ids=split_ids('ensembl_protein_ids', data),
+        )
+
+
+@attr.s()
+class CrossReference(object):
+    ensembl = attr.ib(validator=is_a(EnsemblIds))
+    ref_seq = attr.ib(validator=is_a(RefSeqIds))
+    vega = attr.ib(validator=is_a(VegaIds))
+
+    @classmethod
+    def build(cls, data):
+        return cls(
+            ensembl=EnsemblIds.build(data),
+            ref_seq=RefSeqIds.build(data),
+            vega=VegaIds.build(data),
+        )
+
+
+@attr.s()
+class MGI(object):
+    accession = attr.ib(validator=is_a(basestring))
+    name = attr.ib(validator=is_a(basestring))
+    symbol = attr.ib(validator=is_a(basestring))
+    cross_references = attr.ib(validator=is_a(CrossReference))
+    rna_type = optionally(basestring)
+    location = optionally(Exon)
+
+    @classmethod
+    def build(cls, data):
+        return cls(
+            accession=accession(data),
+            name=name(data),
+            symbol=symbol(data),
+            cross_references=CrossReference.build(data),
+            rna_type=infer_rna_type(data),
+            location=exon(data),
+        )
+
+
+def lines(raw):
+    """
+    Produces an iterable of all ines in the file. This will correct the issues
+    with header being over 2 lines so a normal CSV parser can parse the file.
+    """
+
+    header = '\t'.join([next(raw).strip(), next(raw).strip()])
+    header = header.lower()
+    yield header.replace(' ', '_')
+    for line in raw:
+        yield line
+
+
+def parser(filename):
+    """
+    Parses the file and produces an iterable of all entries as MGI objects.
+    """
+
+    with open(filename, 'rb') as raw:
+        for row in csv.DictReader(lines(raw), delimiter='\t'):
+            yield MGI.build(row)
+
+
+def rna_entries(filename):
+    """
+    Parses the file and produces an iterable of only the RNA entries.
+    """
+
+    for entry in parser(filename):
+        if entry.rna_type is not None:
+            yield entry

--- a/luigi/mgi.py
+++ b/luigi/mgi.py
@@ -15,11 +15,9 @@ limitations under the License.
 
 import csv
 
-import attr
-from attr.validators import instance_of as is_a
-
 from databases.data import Entry
 from databases.data import Exon
+from databases.data import Reference
 from databases import helpers
 
 RNA_TYPE_MAPPING = {
@@ -177,7 +175,20 @@ def primary_id(data):
 
 
 def references(data):
-    return []
+    return [Reference(
+        accession=accession(data),
+        authors=(
+            'Blake JA, Eppig JT, Kadin JA, Richardson JE, Smith CL, Bult CJ; '
+            'the Mouse Genome Database Group.'
+        ),
+        location='Nucleic Acids Res. 2017 Jan 4;',
+        title=(
+            'Mouse Genome Database (MGD)-2017: community knowledge resource '
+            'for the laboratory mouse'
+        ),
+        pmid=27899570,
+        doi='10.1093/nar/gkw1040',
+    )]
 
 
 def mgi_to_entry(data):

--- a/luigi/mgi.py
+++ b/luigi/mgi.py
@@ -149,6 +149,10 @@ def xref_data(data):
             'xr_ids': xr_ids,
             'protein_ids': split_ids('refseq_protein_ids', data),
         },
+        'vega': {
+            'transcript_ids': split_ids('vega_transcript_ids', data),
+            'protein_ids': split_ids('vega_protein_ids', data),
+        },
     }
 
 

--- a/luigi/mgi.py
+++ b/luigi/mgi.py
@@ -136,13 +136,17 @@ def split_ids(name, data):
 
 
 def xref_data(data):
+    ref_trans_all = split_ids('refseq_transcript_ids', data)
+    xr_ids = [tid for tid in ref_trans_all if tid.startswith('XR_')]
+    ref_trans = [tid for tid in ref_trans_all if not tid.startswith('XR_')]
     return {
         'ensembl': {
             'transcript_ids': split_ids('ensembl_transcript_ids', data),
             'protein_ids': split_ids('ensembl_protein_ids', data),
         },
         'ref_seq': {
-            'transcript_ids': split_ids('refseq_transcript_ids', data),
+            'transcript_ids': ref_trans,
+            'xr_ids': xr_ids,
             'protein_ids': split_ids('refseq_protein_ids', data),
         },
     }

--- a/luigi/mgi.py
+++ b/luigi/mgi.py
@@ -176,6 +176,10 @@ def primary_id(data):
     return accession(data)
 
 
+def references(data):
+    return []
+
+
 def mgi_to_entry(data):
     return Entry(
         primary_id=primary_id(data),
@@ -186,9 +190,7 @@ def mgi_to_entry(data):
         exons=exon(data),
         rna_type=infer_rna_type(data) or '',
         url='',
-
         xref_data=xref_data(data),
-
         chromosome=chromosome(data),
         species=species(data),
         common_name=common_name(data),
@@ -199,6 +201,7 @@ def mgi_to_entry(data):
         seq_version='1',
         feature_location_start=start(data),
         feature_location_end=stop(data),
+        references=references(data),
     )
 
 

--- a/luigi/tasks/__init__.py
+++ b/luigi/tasks/__init__.py
@@ -39,3 +39,4 @@ from .secondary_structure import PGLoadSecondaryStructure
 
 from .mgi.download import MgiDownload
 from .mgi.as_json import MgiToJson
+from .mgi import Mgi

--- a/luigi/tasks/__init__.py
+++ b/luigi/tasks/__init__.py
@@ -36,3 +36,6 @@ from .gtrnadb import GtRNAdb
 
 from .secondary_structure import PGLoadAllSecondaryStructures
 from .secondary_structure import PGLoadSecondaryStructure
+
+from .mgi.download import MgiDownload
+from .mgi.as_json import MgiToJson

--- a/luigi/tasks/mgi/__init__.py
+++ b/luigi/tasks/mgi/__init__.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+
+"""
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import luigi
+
+from .rpt_to_csv import MgiToCsv
+from .as_json import MgiToJson
+
+
+class Mgi(luigi.WrapperTask):  # pylint: disable=R0904
+    """
+    This will run the MGI import tasks.
+    """
+
+    def requires(self):
+        yield MgiToCsv()
+        yield MgiToJson()

--- a/luigi/tasks/mgi/as_json.py
+++ b/luigi/tasks/mgi/as_json.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+
+"""
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import os
+import json
+
+import luigi
+from luigi import LocalTarget
+from luigi.local_target import atomic_file
+
+import attr
+
+from tasks.mgi.download import MgiDownload
+from mgi import rna_entries
+
+
+class MgiToJson(luigi.Task):  # pylint: disable=R0904
+    """
+    This will convert the downloaded MGI data to a JSON file containing more
+    structured data for the RNA entries.
+    """
+
+    def requires(self):
+        return MgiDownload()
+
+    def output(self):
+        filename = self.requires().output().fn
+        base = os.path.dirname(filename)
+        return LocalTarget(os.path.join(base, 'rna.json'))
+
+    def run(self):
+        input_file = self.requires().output().fn
+        data = [attr.asdict(e) for e in rna_entries(input_file)]
+        with atomic_file(self.output().fn) as out:
+            json.dump(data, out)

--- a/luigi/tasks/mgi/as_json.py
+++ b/luigi/tasks/mgi/as_json.py
@@ -42,6 +42,12 @@ class MgiToJson(luigi.Task):  # pylint: disable=R0904
 
     def run(self):
         input_file = self.requires().output().fn
-        data = [attr.asdict(e) for e in rna_entries(input_file)]
+        data = []
+        for entry in rna_entries(input_file):
+            result = attr.asdict(entry)
+            result['feature_type'] = entry.feature_type
+            result['ncrna_class'] = entry.ncrna_class
+            data.append(result)
+
         with atomic_file(self.output().fn) as out:
             json.dump(data, out)

--- a/luigi/tasks/mgi/download.py
+++ b/luigi/tasks/mgi/download.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+
+"""
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import os
+
+import luigi
+from luigi import LocalTarget
+from luigi.local_target import atomic_file
+
+import requests
+
+from tasks.config import output
+
+URL = 'http://www.informatics.jax.org/downloads/reports/MRK_Sequence.rpt'
+
+
+class MgiDownload(luigi.Task):  # pylint: disable=R0904
+    """
+    This will download the MGI MRK_Sequence.rpt file for future processing.
+    """
+
+    def output(self):
+        path = os.path.join(output().base, 'mgi', 'MRK_Sequence.rpt')
+        return LocalTarget(path)
+
+    def run(self):
+        filename = self.output().fn
+        dirname = os.path.dirname(filename)
+        if not os.path.exists(dirname):
+            os.makedirs(dirname)
+
+        response = requests.get(URL)
+        response.raise_for_status()
+        with atomic_file(filename) as out:
+            out.write(response.text)

--- a/luigi/tasks/mgi/rpt_to_csv.py
+++ b/luigi/tasks/mgi/rpt_to_csv.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+
+"""
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import os
+
+import luigi
+
+from tasks.config import output
+from tasks.utils.entry_writers import Output
+from tasks.mgi.download import MgiDownload
+
+from mgi import rna_entries
+
+
+class MgiToCsv(luigi.Task):  # pylint: disable=R0904
+    """
+    This will create csv import files for MGI data. This will not produce the
+    xrefs to import or sequences as those are not part of MGI data. Those must
+    be handled by the django map_mgi and import_mgi scripts.
+    """
+
+    def requires(self):
+        return MgiDownload()
+
+    @property
+    def input_file(self):
+        """
+        Get the path of the file to parse.
+        """
+        return self.requires().output().fn
+
+    def output(self):
+        prefix = os.path.basename(self.input_file)
+        return Output.build(output().base, 'mgi', prefix)
+
+    def run(self):
+        with self.output().writer() as writer:
+            for entry in rna_entries(self.input_file):
+                writer.ac_info.write(entry)
+                writer.refs.write(entry)
+                writer.genomic_locations.write(entry)


### PR DESCRIPTION
This adds some simple logic for fetching the MGI data. I would prefer to keep as much import code in the import pipeline. So this contains three major additions. 

First, this can download the MGI data file we can import. This gets saved locally for other things to process.

Secondly, this can parse the downloaded MGI data file to produce a JSON file for the mapping and importing scripts in the webcode to work with. This will parse the data into an Entry object which is normally used to populate the CSV's we import. The advantage of this is that if we do all importing here this will make it much easier as we will have a constant set of objects to work with. I also wanted to keep the logic like inferring RNA type, which this must do, in one place. 

The final thing that this can do is produce *some* of the csv files we need to import. The only part the mapping has to do is create the xref entries, everything else can be imported normally. Now this does tie the MGI import to the main pipeline, but it already is as we have to import Ensembl with it anyway. The other downside is that this does not just create entries for all mapped entries but all entries. This will lead to us having rows in rnc_accession which have no xrefs. I'm not sure if this is a good idea on reflection but  it is worth talking about.

This is being merged into the gtrnadb branch since I used it as a starting point for this work. That branch has the gtrnadb stuff as well as the next design or organisation for my import work.