### PR TITLE
Store ensembl locus in gene

### DIFF
--- a/luigi/databases/ensembl/parsers.py
+++ b/luigi/databases/ensembl/parsers.py
@@ -157,7 +157,7 @@ class EnsemblParser(Parser):
             parent_accession=record.id,
             common_name=common_name,
             species=species,
-            gene=gene,
+            gene=summary.locus_tag(gene),
             locus_tag=summary.locus_tag(gene),
             optional_id=gene,
             note_data=helpers.note_data(feature),

--- a/luigi/tests/ensembl/parsers/generic_test.py
+++ b/luigi/tests/ensembl/parsers/generic_test.py
@@ -37,9 +37,8 @@ class HumanTests(Base):
         assert self.entry_for('ENST00000516089.1').optional_id == \
             "ENSG00000251898.1"
 
-    def test_it_gets_gene_id(self):
-        assert self.entry_for('ENST00000516089.1').gene == \
-            "ENSG00000251898.1"
+    def test_it_gets_gene_id_to_locus(self):
+        assert self.entry_for('ENST00000516089.1').gene == 'SCARNA11'
 
     def test_it_gets_the_locus_tag(self):
         assert self.entry_for('ENST00000516089.1').locus_tag == 'SCARNA11'
@@ -151,7 +150,7 @@ class HumanTests(Base):
             'parent_accession': '12.GRCh38',
             'common_name': 'human',
             'species': 'Homo sapiens',
-            'gene': 'ENSG00000278469.1',
+            'gene': 'Metazoa_SRP',
             'gene_synonyms': [],
             'locus_tag': 'Metazoa_SRP',
             'optional_id': 'ENSG00000278469.1',


### PR DESCRIPTION
This is something Anton and I discussed a while ago. We do not lose data
doing this as we still have gene id in the optional_id. I know this was
an improvement we wanted, but the gain is unclear right now.

We should really do a better job keep data stored in a consistent and 
clear way.