### PR TITLE
Fix issue creating duplicate accessions

### DIFF
--- a/data/rfam-duplicates.json
+++ b/data/rfam-duplicates.json
@@ -1,0 +1,60 @@
+[
+    {
+    "lineage":"Eukaryota Metazoa Chordata Craniata Vertebrata Euteleostomi Mammalia Eutheria Euarchontoglires Primates Haplorrhini Catarrhini Hominidae Homo.",
+    "primary_id":"RF01061",
+    "is_seed":"0",
+    "feature_type":"ncRNA",
+    "feature_location_end":"93286321",
+    "feature_location_start":"93286238",
+    "ontology":[
+      "MIPF:MIPF0000317",
+      "SO:0001244",
+      "GO:0035068",
+      "GO:0035195"
+    ],
+    "sequence":"TATTAAGTTGATGCAAAAGTAATTGCGGTTTTTGCCATTGAAAGTAATGGCAAAAACCGCAATTACTTTTGCATCAACCTAATA",
+    "ncbi_tax_id":"9606",
+    "seq_version":"2",
+    "ncrna_class":"miRNA",
+    "common_name":"Human",
+    "references":[
+      "16505370",
+      "17604727",
+      "20459774",
+      "20733160"
+    ],
+    "species":"Homo sapiens",
+    "optional_id":"mir-548",
+    "parent_accession":"CM000677",
+    "description":"microRNA mir-548"
+  },
+  {
+    "lineage":"Eukaryota Metazoa Chordata Craniata Vertebrata Euteleostomi Mammalia Eutheria Euarchontoglires Primates Haplorrhini Catarrhini Hominidae Homo.",
+    "primary_id":"RF01061",
+    "is_seed":"0",
+    "feature_type":"ncRNA",
+    "feature_location_end":"93286238",
+    "feature_location_start":"93286321",
+    "ontology":[
+      "MIPF:MIPF0000317",
+      "SO:0001244",
+      "GO:0035068",
+      "GO:0035195"
+    ],
+    "sequence":"TATTAGGTTGATGCAAAAGTAATTGCGGTTTTTGCCATTACTTTCAATGGCAAAAACCGCAATTACTTTTGCATCAACTTAATA",
+    "ncbi_tax_id":"9606",
+    "seq_version":"2",
+    "ncrna_class":"miRNA",
+    "common_name":"Human",
+    "references":[
+      "16505370",
+      "17604727",
+      "20459774",
+      "20733160"
+    ],
+    "species":"Homo sapiens",
+    "optional_id":"mir-548",
+    "parent_accession":"CM000677",
+    "description":"microRNA mir-548"
+  }
+]

--- a/luigi/databases/rfam/helpers.py
+++ b/luigi/databases/rfam/helpers.py
@@ -37,10 +37,11 @@ def lineage(data):
 def taxid(data):
     return int(data['ncbi_tax_id'])
 
+
 def feature_location_endpoints(data):
     start = int(data['feature_location_start'])
     stop = int(data['feature_location_end'])
-    return tuple(sorted([start, stop]))
+    return (start, stop)
 
 
 

--- a/luigi/tests/databases/rfam/helpers_test.py
+++ b/luigi/tests/databases/rfam/helpers_test.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+
+"""
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import json
+
+from databases.rfam import helpers
+
+
+def test_builds_correct_accessions():
+    with open('data/rfam-duplicates.json', 'r') as raw:
+        data = json.load(raw)
+
+    accessions = [helpers.accession(d) for d in data]
+
+    assert accessions == [
+        'CM000677.2:93286238..93286321:rfam',
+        'CM000677.2:93286321..93286238:rfam',
+    ]

--- a/luigi/tests/databases/rfam/parser_test.py
+++ b/luigi/tests/databases/rfam/parser_test.py
@@ -134,3 +134,10 @@ def test_it_builds_first_entry_correctly():
         'xref_data': {},
         'secondary_structure': {'dot_bracket': ''},
     }
+
+
+def test_it_can_parse_with_similar_accessions_correctly():
+    data = list(parse('data/rfam-duplicates.json'))
+    assert len(data) == 2
+    assert data[0].accession == 'CM000677.2:93286238..93286321:rfam'
+    assert data[1].accession == 'CM000677.2:93286321..93286238:rfam'


### PR DESCRIPTION
Some entries can have a duplicate accession because I created the
accessions incorrectly. Basically we sort the start, stop when we
shouldn't for some Rfam entries. This fixes that and provides a test
case where two entries have exactly the same start/stop but in different
directions.