### PR TITLE
Prevent adding 'None' to Ensembl descriptions

### DIFF
--- a/luigi/databases/ensembl/helpers/ensembl.py
+++ b/luigi/databases/ensembl/helpers/ensembl.py
@@ -102,8 +102,8 @@ def locus_description(entry):
     return '{species} {rna_type} {locus_tag}'.format(
         species=species,
         rna_type=entry.rna_type.replace('_', ' '),
-        locus_tag=entry.locus_tag,
-    )
+        locus_tag=entry.locus_tag or '',
+    ).strip()
 
 
 def description(summary, feature, entry):

--- a/luigi/tests/databases/ensembl/parsers/generic_test.py
+++ b/luigi/tests/databases/ensembl/parsers/generic_test.py
@@ -231,3 +231,12 @@ class MouseTests(Base):
     def test_it_never_has_bad_vault(self):
         for entry in self.data():
             assert entry.rna_type != 'vaultRNA'
+
+
+class OtherTests(Base):
+    filename = 'data/ensembl/Macaca_mulatta.Mmul_8.0.1.92.chromosome.1.dat'
+    importer_class = EnsemblParser
+
+    def test_does_not_append_none_to_description(self):
+        print(self.features.keys()[0:10])
+        assert self.entry_for('ENSMMUT00000062476.1').description == 'Macaca mulatta (rhesus monkey) lncRNA'

--- a/luigi/tests/databases/ensembl/utils.py
+++ b/luigi/tests/databases/ensembl/utils.py
@@ -34,11 +34,10 @@ class Base(ut.TestCase):  # pylint: disable=R0904
             key = None
             if helpers.is_gene(feature):
                 key = helpers.gene(feature)
-            elif not helpers.is_ncrna(feature):
-                continue
+            elif helpers.is_ncrna(feature):
+                key = helpers.transcript(feature) or \
+                    helpers.standard_name(feature)
 
-            if helpers.is_transcript(feature):
-                key = helpers.transcript(feature)
             if not key:
                 continue
             cls.features[key] = feature


### PR DESCRIPTION
When building a description using the locus_tag we would add None if
there was no locus_tag. This is not ideal and now prevented. Additionally
there is a test to ensure that no longer happens.