### PR TITLE
Search index go terms

### DIFF
--- a/data/export/search/URS000000079A_87230.xml
+++ b/data/export/search/URS000000079A_87230.xml
@@ -31,5 +31,6 @@
 <field name="rfam_problems">missing_match</field>
 <field name="rfam_problem_found">True</field>
 <field name="tax_string">Eukaryota; Fungi; Dikarya; Ascomycota; Pezizomycotina; Leotiomycetes; Helotiales; Sclerotiniaceae; Botrytis; Botrytis tulipae</field>
+<field name="has_go_annotations">False</field>
 </additional_fields>
 </entry>

--- a/luigi/rnacentral/search/data.py
+++ b/luigi/rnacentral/search/data.py
@@ -28,6 +28,14 @@ GENERIC_TYPES = set(['misc_RNA', 'misc RNA', 'other'])
 
 NO_OPTIONAL_IDS = set(['SILVA', 'PDB'])
 
+KNOWN_QUALIFIERS = set([
+    'part_of',
+    'involved_in',
+    'enables',
+    'contributes_to',
+    'colocalizes_with',
+])
+
 POPULAR_SPECIES = set([
     9606,    # human
     10090,   # mouse
@@ -455,6 +463,13 @@ def from_annotation_qualifer(name):
     return fn
 
 
+def has_go_annotations(go_annotations):
+    for annotation in go_annotations:
+        if annotation['qualifier'] in KNOWN_QUALIFIERS:
+            return str(True)
+    return str(False)
+
+
 part_of = from_annotation_qualifer('part_of')
 involved_in = from_annotation_qualifer('involved_in')
 enables = from_annotation_qualifer('enables')
@@ -521,5 +536,6 @@ builder = entry([
         fields('enables', enables, keys='go_annotations'),
         fields('contributes_to', contributes_to, keys='go_annotations'),
         fields('colocalizes_with', colocalizes_with, keys='go_annotations'),
+        field('has_go_annotations', has_go_annotations, keys='go_annotations'),
     ]),
 ])

--- a/luigi/rnacentral/search/data.py
+++ b/luigi/rnacentral/search/data.py
@@ -17,6 +17,7 @@ import re
 import json
 from datetime import datetime as dt
 import operator as op
+import itertools as it
 import collections as coll
 
 from xml.sax import saxutils as sax
@@ -442,6 +443,23 @@ def normalize_rna_type(rna_type):
     return first(rna_type).replace('_', ' ')
 
 
+def from_annotation_qualifer(name):
+    def fn(go_annotations):
+        key = op.itemgetter('qualifier')
+        annotations = it.ifilter(lambda a: key(a) == name, go_annotations)
+        for annotation in annotations:
+            yield annotation['go_term_id']
+            yield annotation['go_name']
+    return fn
+
+
+part_of = from_annotation_qualifer('part_of')
+involved_in = from_annotation_qualifer('involved_in')
+enables = from_annotation_qualifer('enables')
+contributes_to = from_annotation_qualifer('contributes_to')
+colocalizes_with = from_annotation_qualifer('colocalizes_with')
+
+
 builder = entry([
     tag('name', as_name, keys=('upi', 'taxid')),
     tag('description', first),
@@ -496,5 +514,10 @@ builder = entry([
         fields('rfam_problems', rfam_problems, keys='rfam_status'),
         field('rfam_problem_found', problem_found, keys='rfam_status'),
         fields('tax_string', unique, keys='tax_strings'),
+        fields('involved_in', involved_in, keys='go_annotations'),
+        fields('part_of', part_of, keys='go_annotations'),
+        fields('enables', enables, keys='go_annotations'),
+        fields('contributes_to', contributes_to, keys='go_annotations'),
+        fields('colocalizes_with', colocalizes_with, keys='go_annotations'),
     ]),
 ])

--- a/luigi/rnacentral/search/data.py
+++ b/luigi/rnacentral/search/data.py
@@ -447,9 +447,11 @@ def from_annotation_qualifer(name):
     def fn(go_annotations):
         key = op.itemgetter('qualifier')
         annotations = it.ifilter(lambda a: key(a) == name, go_annotations)
+        values = set()
         for annotation in annotations:
-            yield annotation['go_term_id']
-            yield annotation['go_name']
+            values.add(annotation['go_term_id'])
+            values.add(annotation['go_name'])
+        return sorted(values)
     return fn
 
 

--- a/luigi/rnacentral/search/exporter.py
+++ b/luigi/rnacentral/search/exporter.py
@@ -56,8 +56,8 @@ SELECT
         'journals', array_agg(refs.location),
         'pub_titles', array_agg(refs.title),
         'pub_ids', array_agg(refs.id),
-        'pubmed_ids', array_agg(pubmed.ref_pubmed_id) || array_agg(refs.pmid),
-        'dois', array_agg(pubmed.ref_pubmed_id) || array_agg(refs.doi),
+        'pubmed_ids', array_agg(pubmed.ref_pubmed_id::varchar) || array_agg(refs.pmid),
+        'dois', array_agg(pubmed.doi) || array_agg(refs.doi),
         'has_coordinates', array_agg(pre.has_coordinates),
         'rfam_family_names', array_agg(models.short_name),
         'rfam_ids', array_agg(hits.rfam_model_id),
@@ -78,9 +78,12 @@ SELECT
         'locus_tags', array_agg(acc.locus_tag),
         'standard_names', array_agg(acc.standard_name),
         'products', array_agg(acc.product),
-        'go_annotations', json_build_object(
-            'go_term_id', anno.ontology_term_id,
-            'go_name', ont.name,
+        'go_annotations', array_agg(
+            json_build_object(
+                'go_term_id', anno.ontology_term_id,
+                'qualifier', anno.qualifier,
+                'go_name', ont.name
+            )
         )
     )
 FROM xref xref
@@ -106,7 +109,7 @@ ON
 LEFT JOIN ref_pubmed pubmed ON pubmed.ref_pubmed_id = go_map.ref_pubmed_id
 LEFT JOIN ontology_terms ont
 ON
-    ont.ontology_term_id = anno.ontology_term_annotation_id
+    ont.ontology_term_id = anno.ontology_term_id
 WHERE
   xref.deleted = 'N'
   AND %s

--- a/luigi/tests/rnacentral/search/exporter_test.py
+++ b/luigi/tests/rnacentral/search/exporter_test.py
@@ -48,8 +48,10 @@ def load_and_get_additional(upi, field_name):
 
 
 def load_and_get_cross_references(upi, db_name):
-    selector = "./additional_fields/ref[@name='%s']" % db_name
-    return load_and_findall(upi, selector)
+    selector = "./cross_references/ref[@dbname='%s']" % db_name
+    results = load_and_findall(upi, selector)
+    assert results
+    return results
 
 
 def pretty_xml(data):
@@ -73,7 +75,7 @@ def test_it_builds_correct_xml_entries(filename):
 @pytest.mark.parametrize("upi,ans", [  # pylint: disable=E1101
     ('URS00008CC2A4_43179', "Ictidomys tridecemlineatus"),
     ('URS0000713CBE_408172', 'marine metagenome'),
-    ('URS000047774B_77133', 'environmental samples uncultured bacterium'),
+    ('URS000047774B_77133', 'uncultured bacterium'),
 ])
 def test_assigns_species_correctly(upi, ans):
     """
@@ -452,14 +454,13 @@ def test_computes_pub_ids(upi, pub_ids):
     assert val == ans
 
 
-
 @pytest.mark.parametrize('upi,pmid', [  # pylint: disable=E1101
     ('URS000026261D_9606', 27021683),
     ('URS0000614A9B_9606', 28111633)
 ])
 def test_can_add_publications_from_go_annotations(upi, pmid):
-    val = load_and_get_cross_references(upi, 'PUBMED')
-    assert pmid in val
+    val = {c['attrib']['dbkey'] for c in load_and_get_cross_references(upi, 'PUBMED')}
+    assert str(pmid) in val
 
 
 @pytest.mark.parametrize('upi,qualifier,ans', [  # pylint: disable=E1101

--- a/luigi/tests/rnacentral/search/exporter_test.py
+++ b/luigi/tests/rnacentral/search/exporter_test.py
@@ -445,3 +445,34 @@ def test_computes_pub_ids(upi, pub_ids):
     ans = [{'attrib': {'name': 'pub_id'}, 'text': str(p)} for p in pub_ids]
     val = load_and_get_additional(upi, 'pub_id')
     assert val == ans
+
+
+
+@pytest.mark.parametrize('upi,pmid', [  # pylint: disable=E1101
+    ('URS000026261D_9606', 27021683),
+    ('URS0000614A9B_9606', 28111633)
+])
+def test_can_add_publications_from_go_annotations(upi, pmid):
+    val = load_and_get_cross_references(upi, 'PUBMED')
+    assert pmid in val
+
+
+@pytest.mark.parametrize('upi,qualifier,ans', [  # pylint: disable=E1101
+    ('URS000026261D_9606', 'part_of', [
+        'GO:0022625',
+        'cytosolic large ribosomal subunit'
+    ]),
+    ('URS0000614A9B_9606', 'involved_in', [
+        'GO:0010628',
+        'GO:0010629',
+        'GO:0035195',
+        'GO:0060045',
+        'positive regulation of gene expression',
+        'negative regulation of gene expression',
+        'gene silencing by miRNA',
+        'positive regulation of cardiac muscle cell proliferation',
+    ]),
+])
+def test_can_assign_go_annotations(upi, qualifier, ans):
+    val = {a['text'] for a in load_and_get_additional(upi, qualifier)}
+    assert val == ans

--- a/luigi/tests/rnacentral/search/exporter_test.py
+++ b/luigi/tests/rnacentral/search/exporter_test.py
@@ -446,12 +446,11 @@ def test_computes_valid_boost(upi, boost):
 
 @pytest.mark.parametrize('upi,pub_ids', [  # pylint: disable=E1101
     ('URS0000BB15D5_9606', [512936, 527789]),
-    ('URS000019E0CD_9606', [238832, 164929, 538386, 491042, 491041]),
+    ('URS000019E0CD_9606', [238832, 538386, 164929, 491042, 491041]),
 ])
 def test_computes_pub_ids(upi, pub_ids):
-    ans = [{'attrib': {'name': 'pub_id'}, 'text': str(p)} for p in pub_ids]
-    val = load_and_get_additional(upi, 'pub_id')
-    assert val == ans
+    val = sorted(int(a['text']) for a in load_and_get_additional(upi, 'pub_id'))
+    assert val == sorted(pub_ids)
 
 
 @pytest.mark.parametrize('upi,pmid', [  # pylint: disable=E1101
@@ -465,8 +464,8 @@ def test_can_add_publications_from_go_annotations(upi, pmid):
 
 @pytest.mark.parametrize('upi,qualifier,ans', [  # pylint: disable=E1101
     ('URS000026261D_9606', 'part_of', [
-        'GO:0022625',
-        'cytosolic large ribosomal subunit'
+        'GO:0005615',
+        'extracellular space'
     ]),
     ('URS0000614A9B_9606', 'involved_in', [
         'GO:0010628',

--- a/luigi/tests/rnacentral/search/exporter_test.py
+++ b/luigi/tests/rnacentral/search/exporter_test.py
@@ -481,3 +481,15 @@ def test_can_add_publications_from_go_annotations(upi, pmid):
 def test_can_assign_go_annotations(upi, qualifier, ans):
     val = {a['text'] for a in load_and_get_additional(upi, qualifier)}
     assert sorted(val) == sorted(ans)
+
+
+@pytest.mark.parametrize('upi,has', [  # pylint: disable=E1101
+    ('URS000026261D_9606', True),
+    ('URS0000614A9B_9606', True),
+    ('URS000019E0CD_9606', False),
+    ('URS0000003085_7460', False),
+])
+def test_it_can_add_valid_annotations_flag(upi, has):
+    assert load_and_get_additional(upi, "has_go_annotations") == [
+        {'attrib': {'name': 'has_go_annotations'}, 'text': str(has)},
+    ]

--- a/luigi/tests/rnacentral/search/exporter_test.py
+++ b/luigi/tests/rnacentral/search/exporter_test.py
@@ -47,6 +47,11 @@ def load_and_get_additional(upi, field_name):
     return load_and_findall(upi, selector)
 
 
+def load_and_get_cross_references(upi, db_name):
+    selector = "./additional_fields/ref[@name='%s']" % db_name
+    return load_and_findall(upi, selector)
+
+
 def pretty_xml(data):
     ugly = ET.tostring(data)
     parsed = minidom.parseString(ugly.replace('\n', ''))
@@ -475,4 +480,4 @@ def test_can_add_publications_from_go_annotations(upi, pmid):
 ])
 def test_can_assign_go_annotations(upi, qualifier, ans):
     val = {a['text'] for a in load_and_get_additional(upi, qualifier)}
-    assert val == ans
+    assert sorted(val) == sorted(ans)


### PR DESCRIPTION
This is the first pass at allowing indexing of QuickGO annotations. One import thing to note is that I haven't check the performance yet.

Here is an example of some data and then the search terms that will be added:

```
RNAcentral      URS0000604143_559292    enables GO:0005515      PMID:11433018   ECO:0000353     UniProtKB:P32495                20180412        UniProt         go_evidence=IPI
RNAcentral      URS0000604143_559292    enables GO:0030559      PMID:9182768    ECO:0000315                     20060911        SGD             go_evidence=IMP
RNAcentral      URS0000604143_559292    involved_in     GO:0031118      PMID:9182768    ECO:0000315                     20060911        SGD             go_evidence=IMP
RNAcentral      URS0000604143_559292    part_of GO:0005730      PMID:9182768    ECO:0000305     GO:0031118              20060911        SGD             go_evidence=IC
RNAcentral      URS0000604143_559292    part_of GO:0031429      PMID:15923376   ECO:0000353     SGD:S000001131|SGD:S000002367           20060908        SGD             go_evidence=IPI
```

This will add:

```
enables:"GO:0005515"
enables:"protein binding"
enables:"GO:0030559 "
enables:"rRNA pseudouridylation guide activity"
involved_in:"GO:0031118"
involved_in:"rRNA pseudouridine synthesis"
part_of:"GO:0005730"
part_of:"nucleolus"
part_of:"GO:0031429"
part_of:"box H/ACA snoRNP complex"
```

That is to say it indexes these annotations by GO term id and the name of the GO term. It does not use the structure of GO terms to assign any more terms. I could look into that if needed, but it may be a big change as we don't store such information currently. 

Additionally, this adds more cross references to the PUBMED section in cross references. These will be the references from the annotations. No other publication information is added currently. 