### PR TITLE
Export rfam go annotations

### DIFF
--- a/luigi/rnacentral/export/ftp/go_terms.py
+++ b/luigi/rnacentral/export/ftp/go_terms.py
@@ -32,6 +32,7 @@ where
     and pre.rfam_problems != ''
     and '{"has_issue": false}'::jsonb <@ pre.rfam_problems::jsonb
 group by pre.id, go_terms.go_term_id
+order by pre.id
 """
 
 

--- a/luigi/rnacentral/export/ftp/go_terms.py
+++ b/luigi/rnacentral/export/ftp/go_terms.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+
+"""
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from rnacentral.psql import PsqlWrapper
+
+
+QUERY = """
+select
+    pre.id,
+    go_terms.go_term_id,
+    hits.rfam_model_id
+from rnc_rna_precomputed pre
+join xref on xref.upi = pre.upi and xref.taxid = pre.taxid
+join rfam_model_hits hits on hits.upi = pre.upi
+join rfam_go_terms go_terms on hits.rfam_model_id = go_terms.rfam_model_id
+where
+    pre.taxid is not null
+    and xref.deleted = 'N'
+    and pre.rfam_problems is not null
+    and pre.rfam_problems != ''
+    and '{"has_issue": false}'::jsonb <@ pre.rfam_problems::jsonb
+group by pre.id, go_terms.go_term_id
+"""
+
+
+def export(config, handle):
+    psql = PsqlWrapper(config)
+    psql.write_query(handle, QUERY, use='tsv')

--- a/luigi/rnacentral/export/ftp/go_terms.py
+++ b/luigi/rnacentral/export/ftp/go_terms.py
@@ -20,7 +20,7 @@ QUERY = """
 select
     pre.id,
     go_terms.go_term_id,
-    hits.rfam_model_id
+    string_agg(hits.rfam_model_id, '|')
 from rnc_rna_precomputed pre
 join xref on xref.upi = pre.upi and xref.taxid = pre.taxid
 join rfam_model_hits hits on hits.upi = pre.upi
@@ -32,7 +32,6 @@ where
     and pre.rfam_problems != ''
     and '{"has_issue": false}'::jsonb <@ pre.rfam_problems::jsonb
 group by pre.id, go_terms.go_term_id
-order by pre.id
 """
 
 

--- a/luigi/rnacentral/export/ftp/go_terms.py
+++ b/luigi/rnacentral/export/ftp/go_terms.py
@@ -19,21 +19,15 @@ from rnacentral.psql import PsqlWrapper
 QUERY = """
 select
     pre.id,
-    go_terms.go_term_id,
-    string_agg(hits.rfam_model_id, '|')
+    go_terms.ontology_term_id,
+    string_agg('Rfam:' || hits.rfam_model_id, '|')
 from rnc_rna_precomputed pre
 join rfam_model_hits hits on hits.upi = pre.upi
 join rfam_go_terms go_terms on hits.rfam_model_id = go_terms.rfam_model_id
 where
-    exists(
-        select 1
-        from qa_status qa
-        where
-            qa.upi = pre.upi
-            and qa.taxid = pre.taxid
-            and qa.has_issue = false
-    )
-group by pre.id, go_terms.go_term_id
+    exists(select 1 from qa_status qa where qa.upi = pre.upi and qa.taxid = pre.taxid and qa.has_issue = false)
+    and exists(select 1 from xref where xref.upi = pre.upi and xref.taxid = pre.taxid and xref.deleted = 'N')
+group by pre.id, go_terms.ontology_term_id
 """
 
 

--- a/luigi/tasks/config.py
+++ b/luigi/tasks/config.py
@@ -292,6 +292,9 @@ class export(luigi.Config):  # pylint: disable=C0103,R0904
     def ensembl_export(self, *args):
         return self.ftp('ensembl', *args)
 
+    def go(self, *args):
+        return self.ftp('go', *args)
+
 
 class refseq(luigi.Config):  # pylint: disable=C0103,R0904
     base = luigi.Parameter(default='/tmp')

--- a/luigi/tasks/export/ftp/__init__.py
+++ b/luigi/tasks/export/ftp/__init__.py
@@ -20,6 +20,7 @@ from .id_mapping import IdExport
 from .rfam import RfamAnnotationExport
 from .fasta import FastaExport
 from .ensembl import EnsemblExport
+from .go_annotations import GoAnnotationExport
 
 
 class FtpExport(luigi.WrapperTask):
@@ -29,3 +30,4 @@ class FtpExport(luigi.WrapperTask):
         yield RfamAnnotationExport
         yield FastaExport
         yield EnsemblExport
+        yield GoAnnotationExport

--- a/luigi/tasks/export/ftp/go_annotations.py
+++ b/luigi/tasks/export/ftp/go_annotations.py
@@ -26,7 +26,7 @@ from tasks.utils.files import atomic_output
 class GoAnnotationExport(luigi.Task):
     def output(self):
         return luigi.LocalTarget(
-            export().go('rnacentral_annotations.tsv.gz'),
+            export().go('rnacentral_rfam_annotations.tsv.gz'),
             format=luigi.format.Gzip,
         )
 

--- a/luigi/tasks/export/ftp/go_annotations.py
+++ b/luigi/tasks/export/ftp/go_annotations.py
@@ -18,13 +18,15 @@ import luigi
 from tasks.config import db
 from tasks.config import export
 
+from rnacentral.export.ftp import go_terms
+
 from tasks.utils.files import atomic_output
 
 
-class GoAnnotation(luigi.Task):
+class GoAnnotationExport(luigi.Task):
     def output(self):
         return luigi.LocalTarget(export().go('rnacentral_annotations.tsv'))
 
     def run(self):
         with atomic_output(self.output()) as out:
-            export(db(), out)
+            go_terms.export(db(), out)

--- a/luigi/tasks/export/ftp/go_annotations.py
+++ b/luigi/tasks/export/ftp/go_annotations.py
@@ -25,7 +25,10 @@ from tasks.utils.files import atomic_output
 
 class GoAnnotationExport(luigi.Task):
     def output(self):
-        return luigi.LocalTarget(export().go('rnacentral_annotations.tsv'))
+        return luigi.LocalTarget(
+            export().go('rnacentral_annotations.tsv.gz'),
+            format=luigi.format.Gzip,
+        )
 
     def run(self):
         with atomic_output(self.output()) as out:

--- a/luigi/tasks/export/ftp/go_annotations.py
+++ b/luigi/tasks/export/ftp/go_annotations.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+
+"""
+Copyright [2009-2017] EMBL-European Bioinformatics Institute
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import luigi
+
+from tasks.config import db
+from tasks.config import export
+
+from tasks.utils.files import atomic_output
+
+
+class GoAnnotation(luigi.Task):
+    def output(self):
+        return luigi.LocalTarget(export().go('rnacentral_annotations.tsv'))
+
+    def run(self):
+        with atomic_output(self.output()) as out:
+            export(db(), out)


### PR DESCRIPTION
This adds an initial GO term export and makes a change to our database. The query to export GO terms is pretty simple and runs in one chunk in ~90 minutes. As this is a first pass I haven't tried to chunk it yet to produce several files.

However, the change to the database is more important. Basically what I have done is create a table for the quality checks `qa_status`. This is much much easier to query and work with I think. The table looks like:

```sql
CREATE TABLE rnacen.qa_status (
	rna_id varchar(50) NOT NULL,
	upi varchar(30) NULL,
	taxid int4 NOT NULL,
	has_issue bool NOT NULL,
	incomplete_sequence bool NOT NULL,
	possible_contamination bool NOT NULL,
	missing_rfam_match bool NOT NULL,
	CONSTRAINT qa_status_pkey PRIMARY KEY (rna_id),
	CONSTRAINT qa_status_upi_fkey FOREIGN KEY (upi) REFERENCES rna(upi)
)
WITH (
	OIDS=FALSE
) ;
CREATE INDEX qa_status__has_issue ON qa_status USING btree (has_issue) WHERE has_issue;
CREATE INDEX qa_status__upi_taxid ON qa_status USING btree (upi, taxid) ;
```

This table is meant to have one column per check and a simple flag if there is an issue or not. I would rather have a table for this data than a JSON field for querying purposes. Do you guys think this is a good idea? 

I don't yet have a migration that properly populates this table (it only uses the `has_issue` flag and doesn't fill in which issue), but I will develop one shortly. 