### PR TITLE
Fix id export bug

### DIFF
--- a/luigi/rnacentral/export/ftp/id_mapping.py
+++ b/luigi/rnacentral/export/ftp/id_mapping.py
@@ -35,7 +35,6 @@ join rnc_database db on db.id = xref.dbid
 join rnc_rna_precomputed pre on pre.upi = xref.upi and pre.taxid = xref.taxid
 where
     xref.deleted = 'N'
-order by upi, xref.ac
 """
 
 EXAMPLE_SQL = COMPLETE_SQL + " limit 5"

--- a/luigi/rnacentral/export/ftp/id_mapping.py
+++ b/luigi/rnacentral/export/ftp/id_mapping.py
@@ -26,15 +26,13 @@ SELECT
     xref.taxid,
     acc.external_id,
     acc.optional_id,
-    case when acc.feature_name is null
-        then acc.ncrna_class
-        else acc.feature_name
-    end as rna_type,
+    pre.rna_type,
     acc.gene,
     db.descr AS database
 FROM xref
 join rnc_accessions acc on acc.accession = xref.ac
 join rnc_database db on db.id = xref.dbid
+join rnc_rna_precomputed pre on pre.upi = xref.upi and pre.taxid = xref.taxid
 where
     xref.deleted = 'N'
 order by upi, xref.ac


### PR DESCRIPTION
Fixes the issue a user found in our ID mapping. We set the RNA type to ncRNA when it was not a standard INSDC RNA type. Additionally, we now use the RNA type we compute and not the RNA type we are given. 