### PR TITLE
Stream based search export

### DIFF
--- a/luigi/rnacentral/search/data.py
+++ b/luigi/rnacentral/search/data.py
@@ -21,7 +21,7 @@ import itertools as it
 import collections as coll
 
 from xml.sax import saxutils as sax
-import xml.etree.cElementTree as ET
+from lxml import etree
 
 
 GENERIC_TYPES = set(['misc_RNA', 'misc RNA', 'other'])
@@ -65,7 +65,7 @@ def create_tag(root, name, value, attrib={}):
         attr.update(value.get('attrib', {}))
         text = value.get('text', None)
 
-    element = ET.SubElement(root, name, attr)
+    element = etree.SubElement(root, name, attr)
     if text:
 
         if not isinstance(text, basestring):
@@ -159,7 +159,7 @@ def entry(spec):
             upi=data['upi'],
             taxid=data['taxid'],
         )
-        root = ET.Element('entry', {'id': entry_id})
+        root = etree.Element('entry', {'id': entry_id})
         for func in spec:
             func(root, data)
         return root
@@ -168,7 +168,7 @@ def entry(spec):
 
 def section(name, spec):
     def fn(root, data):
-        element = ET.SubElement(root, name)
+        element = etree.SubElement(root, name)
         for func in spec:
             func(element, data)
     return fn

--- a/luigi/rnacentral/search/exporter.py
+++ b/luigi/rnacentral/search/exporter.py
@@ -159,23 +159,24 @@ def write(handle, results):
     string representation of that document which can be saved.
     """
 
-    with etree.xmlfile(handle) as xml:
-        with xml.element('database'):
-            xml.write(E.name('RNAcentral'))
-            xml.write(E.description('a database for non-protein coding RNA sequences'))
-            xml.write(E.release('1.0'))
-            xml.write(E.release_date(date.today().strftime('%d/%m/%Y')))
+    handle.write('<database>')
+    handle.write(etree.tostring(E.name('RNAcentral')))
+    handle.write(etree.tostring(E.description('a database for non-protein coding RNA sequences')))
+    handle.write(etree.tostring(E.release('1.0')))
+    handle.write(etree.tostring(E.release_date(date.today().strftime('%d/%m/%Y'))))
 
-            count = 0
-            with xml.element('entries'):
-                for result in results:
-                    count += 1
-                    xml.write(result)
+    count = 0
+    handle.write('<entries>')
+    for result in results:
+        count += 1
+        handle.write(etree.tostring(result))
+    handle.write('</entries>')
 
-            if not count:
-                raise ValueError("No entries found")
+    if not count:
+        raise ValueError("No entries found")
 
-            xml.write(E.entry_count(str(count)))
+    handle.write(etree.tostring(E.entry_count(str(count))))
+    handle.write('</database>')
 
 
 def validate(filename):

--- a/luigi/rnacentral/search/exporter.py
+++ b/luigi/rnacentral/search/exporter.py
@@ -66,8 +66,6 @@ SELECT
         'rfam_status',
             case
                 when cardinality((array_agg(pre.rfam_problems))) = 0 then '{{}}'
-                when (array_agg(pre.rfam_problems))[1] = '' then '{{}}'
-                when (array_agg(pre.rfam_problems))[1] is null then '{{}}'
                 else (array_agg(pre.rfam_problems))[1]::json
             end,
         'tax_strings', array_agg(acc.classification),

--- a/luigi/rnacentral/search/exporter.py
+++ b/luigi/rnacentral/search/exporter.py
@@ -159,23 +159,23 @@ def write(handle, results):
     string representation of that document which can be saved.
     """
 
-    with etree.xmlfile(handle) as xf:
-        with xf.element('database'):
-            xf.write(E.name('RNAcentral'))
-            xf.write(E.description('a database for non-protein coding RNA sequences'))
-            xf.write(E.release('1.0'))
-            xf.write(E.release_date(date.today().strftime('%d/%m/%Y')))
+    with etree.xmlfile(handle) as xml:
+        with xml.element('database'):
+            xml.write(E.name('RNAcentral'))
+            xml.write(E.description('a database for non-protein coding RNA sequences'))
+            xml.write(E.release('1.0'))
+            xml.write(E.release_date(date.today().strftime('%d/%m/%Y')))
 
             count = 0
-            with xf.element('entries'):
+            with xml.element('entries'):
                 for result in results:
                     count += 1
-                    xf.write(result)
+                    xml.write(result)
 
             if not count:
                 raise ValueError("No entries found")
 
-            xf.write(E.entry_count(str(count)))
+            xml.write(E.entry_count(str(count)))
 
 
 def validate(filename):

--- a/luigi/rnacentral/utils.py
+++ b/luigi/rnacentral/utils.py
@@ -16,6 +16,15 @@ limitations under the License.
 from .db import cursor
 
 
+def ranges_between(start, stop, max_size):
+    for start in xrange(start, stop, max_size):
+        last = min(start + max_size, stop)
+        yield (start, last)
+
+    if last < stop:
+        yield (last, stop)
+
+
 def upi_ranges(dbconf, max_size):
     """
     This will create range of the ids for all UPI's in the database.
@@ -25,8 +34,4 @@ def upi_ranges(dbconf, max_size):
         cur.execute('select max(id) from rna')
         stop = cur.fetchone()[0]
 
-    for start in xrange(1, stop, max_size):
-        yield (start, start + max_size)
-
-    if start < stop:
-        yield (start, stop)
+    return ranges_between(1, stop, max_size)

--- a/luigi/tests/rnacentral/search/exporter_test.py
+++ b/luigi/tests/rnacentral/search/exporter_test.py
@@ -306,10 +306,7 @@ def test_can_assign_correct_cross_references(upi, ans):
 
 
 def test_can_create_document_with_unicode():
-    data = load_and_get_additional('URS000009EE82_562', 'product')
-    from pprint import pprint
-    pprint(data)
-    assert data == [
+    assert load_and_get_additional('URS000009EE82_562', 'product') == [
         {'attrib': {'name': 'product'}, 'text': u'tRNA-Asp(gtc)'},
         {'attrib': {'name': 'product'}, 'text': u'P-site tRNA Aspartate'},
         {'attrib': {'name': 'product'}, 'text': u'transfer RNA-Asp'},

--- a/luigi/tests/rnacentral/search/exporter_test.py
+++ b/luigi/tests/rnacentral/search/exporter_test.py
@@ -353,6 +353,18 @@ def test_output_validates_according_to_schema():
         exporter.validate(out.name)
 
 
+def test_produces_correct_count():
+    entries = exporter.range(db(), 1, 100)
+    with tempfile.NamedTemporaryFile() as out:
+        exporter.write(out, entries)
+        out.flush()
+        with open(out.name, 'r') as raw:
+            parsed = ET.parse(raw)
+            count = parsed.find('./entry_count')
+            assert count.text == '105'
+
+
+
 @pytest.mark.parametrize('upi,ans', [  # pylint: disable=E1101
     ('URS0000759CF4_9606', 9606),
     ('URS0000724ACA_7955', 7955),

--- a/luigi/tests/rnacentral/utils_test.py
+++ b/luigi/tests/rnacentral/utils_test.py
@@ -13,13 +13,48 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+from rnacentral.utils import ranges_between
 from rnacentral.utils import upi_ranges
 from tasks.config import db
 
 
+def test_ranges_between_handles_simple_ranges():
+    ranges = list(ranges_between(1, 10, 1))
+    assert ranges == [
+        (1, 2),
+        (2, 3),
+        (3, 4),
+        (4, 5),
+        (5, 6),
+        (6, 7),
+        (7, 8),
+        (8, 9),
+        (9, 10),
+    ]
+
+
+def test_ranges_between_handles_ranges_too_small():
+    ranges = list(ranges_between(1, 10, 3))
+    assert ranges == [
+        (1, 4),
+        (4, 7),
+        (7, 10),
+    ]
+
+
+def test_ranges_between_handles_ranges_too_big():
+    ranges = list(ranges_between(1, 11, 3))
+    assert ranges == [
+        (1, 4),
+        (4, 7),
+        (7, 10),
+        (10, 11),
+    ]
+
+
 def test_can_get_range_of_all_upis():
     ranges = list(upi_ranges(db(), 100000))
-    assert len(ranges) == 136
+    assert len(ranges) == 135
 
 
 def test_can_get_correct_upi_ranges():
@@ -28,4 +63,4 @@ def test_can_get_correct_upi_ranges():
         (1, 100001),
         (100001, 200001),
     ]
-    assert ranges[-1] == (13400001, 13458282L)
+    assert ranges[-1] == (13400001, 13437640)

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ functools32==3.2.3-2
 psycopg2==2.7.3.2
 jsonschema==2.6.0
 contextlib2==0.5.5
+lxml==4.2.1


### PR DESCRIPTION
This changes the search export logic so that we now have a stream based export. Previously we had to generate the entire list of all entries to write. Now we do not generate the entire list in memory and instead just iterate over results. This doesn't look like it improves run time greatly (though I didn't check much), but it does a great job at cutting memory usage down from from ~70G to ~70M. The export still validates according to the schema so everything should be fine. 