### PR TITLE
Fix go term export

### DIFF
--- a/files/ftp-export/go_annotations/rnacentral_rfam_annotations.sql
+++ b/files/ftp-export/go_annotations/rnacentral_rfam_annotations.sql
@@ -1,10 +1,12 @@
 COPY (
 select
-    pre.id,
-    pre.upi,
-    pre.taxid,
-    go_terms.ontology_term_id,
-    string_agg('Rfam:' || hits.rfam_model_id, '|') as models
+  json_build_object(
+    'id', pre.id,
+    'upi', pre.upi,
+    'taxid', pre.taxid,
+    'ontology_term_id', go_terms.ontology_term_id,
+    'models', string_agg('Rfam:' || hits.rfam_model_id, '|')
+  )
 from rnc_rna_precomputed pre
 join rfam_model_hits hits on hits.upi = pre.upi
 join rfam_go_terms go_terms on hits.rfam_model_id = go_terms.rfam_model_id

--- a/rnacentral_pipeline/__main__.py
+++ b/rnacentral_pipeline/__main__.py
@@ -38,6 +38,7 @@ from rnacentral_pipeline.rnacentral.ftp_export import fasta
 from rnacentral_pipeline.rnacentral.ftp_export import id_mapping
 from rnacentral_pipeline.rnacentral.ftp_export import release_note
 from rnacentral_pipeline.rnacentral.ftp_export import ensembl as ensembl_json
+from rnacentral_pipeline.rnacentral.ftp_export import go_terms
 
 
 @click.group()
@@ -341,6 +342,13 @@ def export_ensembl(raw, output, schema=None):
     expected schema.
     """
     ensembl_json.generate_file(raw, output, schema_file=schema)
+
+
+@ftp_export.command('rfam-go-annotations')
+@click.argument('filename', type=click.File('rb'))
+@click.argument('output', default='-', type=click.File('wb'))
+def export_go_temrs(filename, output):
+    go_terms.export(filename, output)
 
 
 @ftp_export.group('coordinates')

--- a/rnacentral_pipeline/rnacentral/ftp_export/go_terms.py
+++ b/rnacentral_pipeline/rnacentral/ftp_export/go_terms.py
@@ -14,6 +14,7 @@ limitations under the License.
 """
 
 import csv
+import json
 import itertools as it
 
 
@@ -34,17 +35,21 @@ def exclude_uncultured(annotation):
     return int(annotation['taxid']) not in UNCULTURED_TAXIDS
 
 
+def parse(handle):
+    data = it.imap(json.loads, handle)
+    data = it.ifilter(exclude_uncultured, data)
+    return data
+
+
 def export(handle, output):
     """
     Write the Rfam based GO annotations to the given handle.
     """
 
-    data = csv.DictReader(handle)
-    data = it.ifilter(exclude_uncultured, data)
     writer = csv.DictWriter(
         output,
         ['id', 'ontology_term_id', 'models'],
         extrasaction='ignore',
         delimiter='\t',
     )
-    writer.writerows(data)
+    writer.writerows(parse(handle))


### PR DESCRIPTION
Fix an issue with not calling the go term export code. Along the way I made it easier to debug as well as moved to the JSON based query output. I prefer that style as it is easier to work with downstream.