### PR TITLE
Database specific fasta files

### DIFF
--- a/bin/json2fasta.py
+++ b/bin/json2fasta.py
@@ -14,7 +14,7 @@ def sequences(handle):
         data = json.loads(line)
         description = data.get('description', None)
         if description:
-            description = unicode(description)
+            description = description.encode('utf-8', 'ignore')
 
         yield SeqRecord(
             Seq(data['sequence']),

--- a/files/ftp-export/sequences/database-specific.sql
+++ b/files/ftp-export/sequences/database-specific.sql
@@ -10,6 +10,6 @@ JOIN rna ON rna.upi = pre.upi
 WHERE
     pre.is_active = true
     AND pre.taxid is not null
-    AND pre.databases ilike '%:db%'
+    AND pre.databases ilike :'db'
 ) TO STDOUT
 

--- a/files/ftp-export/sequences/database-specific.sql
+++ b/files/ftp-export/sequences/database-specific.sql
@@ -1,0 +1,15 @@
+COPY (
+SELECT
+    json_build_object(
+      'id', pre.id,
+      'description', pre.description,
+      'sequence', COALESCE(rna.seq_short, rna.seq_long)
+    )
+FROM rnc_rna_precomputed pre
+JOIN rna ON rna.upi = pre.upi
+WHERE
+    pre.is_active = true
+    AND pre.taxid is not null
+    AND pre.databases ilike '%:db%'
+) TO STDOUT
+

--- a/files/ftp-export/sequences/databases.sql
+++ b/files/ftp-export/sequences/databases.sql
@@ -1,0 +1,7 @@
+COPY (
+select
+  descr
+from rnc_database
+where
+  alive = 'Y'
+);

--- a/files/ftp-export/sequences/databases.sql
+++ b/files/ftp-export/sequences/databases.sql
@@ -4,4 +4,5 @@ select
 from rnc_database
 where
   alive = 'Y'
-);
+  and num_sequences > 0
+) TO STDOUT

--- a/ftp-export.nf
+++ b/ftp-export.nf
@@ -163,19 +163,23 @@ raw_dbs
   .set { db_sequences }
 
 process database_specific_fasta {
+  maxForks 4
+
   publishDir "${params.ftp_export.publish}/sequences/.search", mode: 'move'
 
   input:
   set val(db), file(query) from db_sequences
 
   output:
-  file "${db}.fasta.gz" into __sequences_species
+  file(name) into __sequences_species
 
+  script:
+  name = "${db.toLowerCase()}.fasta"
   """
   set -o pipefail
 
   export PYTHONIOENCODING=utf8
-  psql -f "$query" -v db=${db} "$PGDATABASE" | json2fasta.py - - | gzip > ${db}.fasta.gz
+  psql -f "$query" -v db='%${db}%' "$PGDATABASE" | json2fasta.py - $name
   """
 }
 

--- a/ftp-export.nf
+++ b/ftp-export.nf
@@ -179,7 +179,8 @@ process database_specific_fasta {
   set -o pipefail
 
   export PYTHONIOENCODING=utf8
-  psql -f "$query" -v db='%${db}%' "$PGDATABASE" | json2fasta.py - $name
+  psql -f "$query" -v db='%${db}%' "$PGDATABASE" > raw.json
+  json2fasta.py raw.json $name
   """
 }
 


### PR DESCRIPTION
These are needed for the new search system. We generate a fasta file per database with all sequences found in that database. This should allow for faster searching with the new setup. There are also changes to try to deal with unicode issues, again.