### PR TITLE
Do not use common names from rnc_accessions

### DIFF
--- a/files/search-export/parts/accessions.sql
+++ b/files/search-export/parts/accessions.sql
@@ -4,7 +4,7 @@ COPY (
       'id', todo.search_export_id,
       'urs_taxid', todo.urs_taxid,
       'accession', todo.accession,
-      'common_name', COALESCE(tax.common_name, todo.common_name),
+      'common_name', tax.common_name,
       'database', todo.database,
       'external_id', todo.external_id,
       'function', todo.function,


### PR DESCRIPTION
Fixes https://github.com/RNAcentral/rnacentral-webcode/issues/75. I'm fairly certain the issue with weird common names stems from the parsing that is used to build the rnc_accessions table. For some databases (probably only ENA) we parse the names we are given to extract a common name. This is unreliable. But we don't need to fix that (if it is even possible), because we have a better source taxonomy information, rnc_taxonomy. That table is based of the NCBI taxonomy and uses the official names for species, no need for parsing to extract common names. Thus, we stop using the common_name from rnc_accessions and just use the one from rnc_taxonomy.

What this does not change is the usage of the species or lineage from the rnc_accessions table. This should be done, eventually, but before that we have to ensure there is always an entry in rnc_taxonomy for all taxids in xref/accession. This may not be true currently, and is not yet enforced, so I leave those lines alone.