### PR TITLE
RNA-285: Export more mirbase ids

### DIFF
--- a/rnacentral_pipeline/rnacentral/ftp_export/id_mapping.py
+++ b/rnacentral_pipeline/rnacentral/ftp_export/id_mapping.py
@@ -26,6 +26,9 @@ def gene(result):
     if result["database"] == "ENSEMBL":
         return result["optional_id"]
 
+    if result["database"] == "MIRBASE":
+        return result["optional_id"]
+
     if result["rna_type"] == "piRNA" and result["database"] == "ENA":
         return result["product"]
 

--- a/tests/rnacentral/ftp_export/id_mapping_test.py
+++ b/tests/rnacentral/ftp_export/id_mapping_test.py
@@ -122,6 +122,15 @@ def test_can_create_accession(data, expected):
             },
             "bob",
         ),
+        (
+            {
+                "gene": "gene1",
+                "database": "MIRBASE",
+                "optional_id": "hsa-mir-1",
+                "rna_type": "miRNA",
+            },
+            "hsa-mir-1",
+        ),
     ],
 )
 def test_can_generate_gene(data, expected):
@@ -223,6 +232,16 @@ def test_as_entry_works_correctly():
                 ],
             ],
         ),
+        # (
+        #     "URS000069C337_9606",
+        #     [
+        #         ["URS000069C337_9606", "ENSEMBL", "ENST00000401212", 9606, "pre-miRNA", "MIR298"],
+        #         ["URS000069C337_9606", "GENECARDS", "", 9606, "pre-miRNA", "MIR298"],
+        #         ["URS000069C337_9606", "MALACARDS", "", 9606, "pre-miRNA", "MIR298"],
+        #         ["URS000069C337_9606", "MIRBASE", "", 9606, "pre-miRNA", "MIR298"],
+        #         ["URS000069C337_9606", "REFSEQ", "", 9606, "pre-miRNA", "MIR298"],
+        #     ]
+        # ),
     ],
 )
 def test_can_create_expected_exports(rna_id, expected):


### PR DESCRIPTION
It would be useful to have more miRBase identifiers for people to use. It turns out to be hard to create the mappings outside of RNAcentral but easy for us to export them, so we might as well export them.