### PR TITLE
Write URL to it's own column

### DIFF
--- a/files/import-data/load/accessions.ctl
+++ b/files/import-data/load/accessions.ctl
@@ -28,7 +28,8 @@ HAVING FIELDS (
     product,
     standard_name,
     db_xref,
-    so_term
+    so_term,
+    url
 )
 INTO {{PGDATABASE}}?load_rnc_accessions
 TARGET COLUMNS (
@@ -59,7 +60,8 @@ TARGET COLUMNS (
     product,
     standard_name,
     db_xref,
-    so_term
+    so_term,
+    url
 )
 
 WITH truncate,

--- a/rnacentral_pipeline/databases/data/entry.py
+++ b/rnacentral_pipeline/databases/data/entry.py
@@ -281,6 +281,7 @@ class Entry:
             self.standard_name,
             self.db_xrefs,
             self.rna_type,
+            self.url,
         ]
 
     def write_secondary_structure(self) -> ty.List[str]:


### PR DESCRIPTION
This change writes the URL, if any, to the URL column which is then loaded and put into rnc_accessions. At the moment that column does not exist in the load_ or final table and so needs to be before this is merged. Additionally, this does not stop writing the URL in the note field to not break things for the upcoming release.

Once this is merged, we need to add the column, defaulting to NULL to accessions and the load_ table. Then the update function needs to be updated. We then should test out using this column instead of however URLs for accessions are calculated now. That can wait until after this release. Future work should move the schema for these tables and function into a controlled location, be it here or the web repo.