### PR TITLE
Removes updating the rnc_sequence_regions.providing_databases column

### DIFF
--- a/files/schema/create_load.sql
+++ b/files/schema/create_load.sql
@@ -175,8 +175,7 @@ CREATE TABLE load_rnc_sequence_regions (
     exon_start int4,
     exon_stop int4,
     assembly_id varchar(255),
-    exon_count int,
-    providing_database text
+    exon_count int
 );
 
 DROP TABLE IF EXISTS load_rnc_related_sequences;


### PR DESCRIPTION
This change is to remove the rnc_sequence_regions.providing_databases column. It removes all updating logic for it. However, as an effect of this it has a subtle effect on how we need to fetch and display known coordinates. What this will do is no longer delete inactive coordinates. This is ok because we map coordinates to accessions (via rnc_accession_sequence_region) and track which accessions are active (via xref) so we can always tell which provided coordinates are active.

This means though that we need to be careful when extracting active coordinates as we have to check if the xrefs are active. This is a major change from before where we always assumed all entries in the table are active. I think this is ok, as the reduction in logic will be fine and the databases that provide the majority of our coordinates don't obsolete that many coordinates, I hope.