### PR TITLE
The genome browser pop-up should show the description (RNA-369)

### DIFF
--- a/files/ftp-export/genome_coordinates/query.sql
+++ b/files/ftp-export/genome_coordinates/query.sql
@@ -4,7 +4,7 @@ SELECT
       'assembly_id', :'assembly_id',
       'region_id', max(regions.region_name),
       'rna_id', max(pre.id),
-      'description', max(pre.description),
+      'description', max(pre.short_description),
       'rna_type',  max(pre.rna_type),
       'databases', regexp_split_to_array(max(pre."databases"), ','),
       'providing_databases', max(regions.providing_databases),

--- a/files/ftp-export/genome_coordinates/query.sql
+++ b/files/ftp-export/genome_coordinates/query.sql
@@ -4,6 +4,7 @@ SELECT
       'assembly_id', :'assembly_id',
       'region_id', max(regions.region_name),
       'rna_id', max(pre.id),
+      'description', max(pre.description),
       'rna_type',  max(pre.rna_type),
       'databases', regexp_split_to_array(max(pre."databases"), ','),
       'providing_databases', max(regions.providing_databases),

--- a/rnacentral_pipeline/rnacentral/ftp_export/coordinates/data.py
+++ b/rnacentral_pipeline/rnacentral/ftp_export/coordinates/data.py
@@ -60,6 +60,7 @@ class Region(object):
         region_id = "{rna_id}.{index}".format(rna_id=raw["rna_id"], index=index)
 
         metadata = {
+            "description": raw["description"],
             "rna_type": raw["rna_type"],
             "providing_databases": clean_databases(raw["providing_databases"]),
             "databases": clean_databases(raw["databases"]),

--- a/rnacentral_pipeline/rnacentral/ftp_export/coordinates/gff3.py
+++ b/rnacentral_pipeline/rnacentral/ftp_export/coordinates/gff3.py
@@ -34,6 +34,7 @@ def regions_as_features(regions: ty.Iterable[coord.Region]) -> ty.Iterable[Featu
         attributes = OrderedDict(
             [
                 ("Name", [region.rna_id]),
+                ("description", [region.metadata["description"]]),
                 ("type", [region.metadata["rna_type"]]),
                 ("databases", region.metadata["databases"]),
                 ("ID", [region.region_id]),
@@ -63,6 +64,7 @@ def regions_as_features(regions: ty.Iterable[coord.Region]) -> ty.Iterable[Featu
             exon_attributes = OrderedDict(
                 [
                     ("Name", [region.rna_id]),
+                    ("description", [region.metadata["description"]]),
                     ("type", [region.metadata["rna_type"]]),
                     ("databases", region.metadata["databases"]),
                     ("ID", [exon_id]),

--- a/workflows/export/ftp/coordinates.nf
+++ b/workflows/export/ftp/coordinates.nf
@@ -94,6 +94,7 @@ process generate_gff3_for_igv {
 
   rnac ftp-export coordinates as-gff3 $raw_data - |\
   sort -t"`printf '\\t'`" -k1,1 -k4,4n |\
+  sed s/noncoding_exon/exon/g |\
   bgzip > "${species}.${assembly}.rnacentral.gff3.gz"
   """
 }


### PR DESCRIPTION
I have added the description field from the rnc_rna_precomputed table to the gff file. This is a simple change but it does not only affect the files used by IGV, since this field will also be present on the FTP server within the genome_coordinates directory.