### PR TITLE
Blake/rna 533 fix genome coordinate export

### DIFF
--- a/files/ftp-export/genome_coordinates/query.sql
+++ b/files/ftp-export/genome_coordinates/query.sql
@@ -21,10 +21,8 @@ ON
 JOIN rnc_sequence_exons exons
 ON
   exons.region_id = regions.id
-join rnc_accession_sequence_region sra
-	on sra.region_id = regions.id
-join rnc_accessions ac
-	on sra.accession = ac.accession
+LEFT JOIN rnc_accession_sequence_region sra on sra.region_id = regions.id
+LEFT JOIN rnc_accessions ac on sra.accession = ac.accession
 WHERE
   pre.is_active = true
   AND regions.assembly_id = :'assembly_id'

--- a/rnacentral_pipeline/databases/data/databases.py
+++ b/rnacentral_pipeline/databases/data/databases.py
@@ -22,6 +22,16 @@ import typing as ty
 class DatabaseValue(ty.NamedTuple):
     id: int
     pretty: str
+    descr: str
+
+    def matches(self, key: int | str) -> bool:
+        if isinstance(key, int):
+            return key == self.id
+        if isinstance(key, str):
+            return (
+                key.lower() == self.pretty.lower() or key.lower() == self.descr.lower()
+            )
+        raise ValueError(f"Cannot match {key}")
 
 
 @enum.unique
@@ -31,59 +41,59 @@ class Database(enum.Enum):
     knows about.
     """
 
-    crw = DatabaseValue(0, "CRW")
-    dictybase = DatabaseValue(1, "DictyBase")
-    ena = DatabaseValue(2, "ENA")
-    ensembl = DatabaseValue(3, "Ensembl")
-    ensembl_fungi = DatabaseValue(4, "Ensembl Fungi")
-    ensembl_metazoa = DatabaseValue(5, "Ensembl Metazoa")
-    ensembl_plants = DatabaseValue(6, "Ensembl Plants")
-    ensembl_protists = DatabaseValue(7, "Ensembl Protists")
-    evlncrnas = DatabaseValue(53, "EVlncRNAs")
-    expression_atlas = DatabaseValue(51, "Expression Atlas")
-    five_srrnadb = DatabaseValue(8, "5SrRNAdb")
-    flybase = DatabaseValue(9, "FlyBase")
-    gencode = DatabaseValue(10, "Ensembl/GENCODE")
-    genecards = DatabaseValue(11, "GeneCards")
-    greengenes = DatabaseValue(12, "Greengenes")
-    gtrnadb = DatabaseValue(13, "GtRNAdb")
-    hgnc = DatabaseValue(14, "HGNC")
-    intact = DatabaseValue(15, "IntAct")
-    lncbase = DatabaseValue(16, "LncBase")
-    lncbook = DatabaseValue(17, "LncBook")
-    lncipedia = DatabaseValue(18, "LNCipedia")
-    lncrnadb = DatabaseValue(19, "lncRNAdb")
-    malacards = DatabaseValue(20, "MalaCards")
-    mgi = DatabaseValue(21, "MGI")
-    mgnify = DatabaseValue(55, "MGNIFY")
-    mirbase = DatabaseValue(22, "miRBase")
-    mirgenedb = DatabaseValue(23, "MirGeneDB")
-    modomics = DatabaseValue(24, "Modomics")
-    noncode = DatabaseValue(25, "NONCODE")
-    pdbe = DatabaseValue(26, "PDBe")
-    pirbase = DatabaseValue(27, "PirBase")
-    plncdb = DatabaseValue(50, "PLncDB")
-    pombase = DatabaseValue(28, "PomBase")
-    psicquic = DatabaseValue(48, "PSICQUIC")
-    rdp = DatabaseValue(29, "RDP")
-    refseq = DatabaseValue(30, "RefSeq")
-    ribocentre = DatabaseValue(52, "RiboCentre")
-    ribovision = DatabaseValue(49, "RiboVision")
-    rfam = DatabaseValue(31, "Rfam")
-    rgd = DatabaseValue(32, "RGD")
-    sgd = DatabaseValue(33, "SGD")
-    silva = DatabaseValue(34, "SILVA")
-    snodb = DatabaseValue(35, "snoDB")
-    snopy = DatabaseValue(36, "snOPY")
-    snorna_database = DatabaseValue(37, "snoRNA Database")
-    srpdb = DatabaseValue(38, "SRPDB")
-    tair = DatabaseValue(39, "TAIR")
-    tarbase = DatabaseValue(40, "TarBase")
-    tmrna_website = DatabaseValue(41, "tmRNA Website")
-    vega = DatabaseValue(42, "VEGA")
-    wormbase = DatabaseValue(43, "WormBase")
-    zfin = DatabaseValue(44, "Zfin")
-    zwd = DatabaseValue(45, "ZWD")
+    crw = DatabaseValue(0, "CRW", "CRW")
+    dictybase = DatabaseValue(1, "DictyBase", "DICTYBASE")
+    ena = DatabaseValue(2, "ENA", "ENA")
+    ensembl = DatabaseValue(3, "Ensembl", "ENSEMBL")
+    ensembl_fungi = DatabaseValue(4, "Ensembl Fungi", "ENSEMBL_FUNGI")
+    ensembl_metazoa = DatabaseValue(5, "Ensembl Metazoa", "ENSEMBL_METAZOA")
+    ensembl_plants = DatabaseValue(6, "Ensembl Plants", "ENSEMBL_PLANTS")
+    ensembl_protists = DatabaseValue(7, "Ensembl Protists", "ENSEMBL_PROTISTS")
+    evlncrnas = DatabaseValue(53, "EVlncRNAs", "EVLNCRNAS")
+    expression_atlas = DatabaseValue(51, "Expression Atlas", "Expression Atlas")
+    five_srrnadb = DatabaseValue(8, "5SrRNAdb", "5SRRNADB")
+    flybase = DatabaseValue(9, "FlyBase", "FLYBASE")
+    gencode = DatabaseValue(10, "Ensembl/GENCODE", "ENSEMBL_GENCODE")
+    genecards = DatabaseValue(11, "GeneCards", "GENECARDS")
+    greengenes = DatabaseValue(12, "Greengenes", "GREENGENES")
+    gtrnadb = DatabaseValue(13, "GtRNAdb", "GTRNADB")
+    hgnc = DatabaseValue(14, "HGNC", "HGNC")
+    intact = DatabaseValue(15, "IntAct", "INTACT")
+    lncbase = DatabaseValue(16, "LncBase", "LNCBASE")
+    lncbook = DatabaseValue(17, "LncBook", "LNCBOOK")
+    lncipedia = DatabaseValue(18, "LNCipedia", "LNCIPEDIA")
+    lncrnadb = DatabaseValue(19, "lncRNAdb", "LNCRNADB")
+    malacards = DatabaseValue(20, "MalaCards", "MALACARDS")
+    mgi = DatabaseValue(21, "MGI", "MGI")
+    mgnify = DatabaseValue(55, "MGNIFY", "MGNIFY")
+    mirbase = DatabaseValue(22, "miRBase", "MIRBASE")
+    mirgenedb = DatabaseValue(23, "MirGeneDB", "MIRGENEDB")
+    modomics = DatabaseValue(24, "Modomics", "MODOMICS")
+    noncode = DatabaseValue(25, "NONCODE", "NONCODE")
+    pdbe = DatabaseValue(26, "PDBe", "PDBE")
+    pirbase = DatabaseValue(27, "PirBase", "PIRBASE")
+    plncdb = DatabaseValue(50, "PLncDB", "PLNCDB")
+    pombase = DatabaseValue(28, "PomBase", "POMBASE")
+    psicquic = DatabaseValue(48, "PSICQUIC", "PSICQUIC")
+    rdp = DatabaseValue(29, "RDP", "RDP")
+    refseq = DatabaseValue(30, "RefSeq", "REFSEQ")
+    ribocentre = DatabaseValue(52, "RiboCentre", "RIBOCENTRE")
+    ribovision = DatabaseValue(49, "RiboVision", "RIBOVISION")
+    rfam = DatabaseValue(31, "Rfam", "RFAM")
+    rgd = DatabaseValue(32, "RGD", "RGD")
+    sgd = DatabaseValue(33, "SGD", "SGD")
+    silva = DatabaseValue(34, "SILVA", "SILVA")
+    snodb = DatabaseValue(35, "snoDB", "SNODB")
+    snopy = DatabaseValue(36, "snOPY", "SNOPY")
+    snorna_database = DatabaseValue(37, "snoRNA Database", "SNORNADB")
+    srpdb = DatabaseValue(38, "SRPDB", "SRPDB")
+    tair = DatabaseValue(39, "TAIR", "TAIR")
+    tarbase = DatabaseValue(40, "TarBase", "TARBASE")
+    tmrna_website = DatabaseValue(41, "tmRNA Website", "TMRNA_WEB")
+    vega = DatabaseValue(42, "VEGA", "VEGA")
+    wormbase = DatabaseValue(43, "WormBase", "WORMBASE")
+    zfin = DatabaseValue(44, "Zfin", "ZFIN")
+    zwd = DatabaseValue(45, "ZWD", "ZWD")
 
     @classmethod
     def build(cls, name: str) -> Database:
@@ -105,6 +115,13 @@ class Database(enum.Enum):
         if attribute == "snornadb":
             return cls.snorna_database
         raise ValueError("Unknown database name %s" % name)
+
+    @classmethod
+    def lookup(cls, db: int | str) -> Database | None:
+        for value in list(cls):
+            if value.value.matches(db):
+                return value
+        return None
 
     def normalized(self) -> str:
         if self is Database.gencode:

--- a/rnacentral_pipeline/rnacentral/ftp_export/coordinates/data.py
+++ b/rnacentral_pipeline/rnacentral/ftp_export/coordinates/data.py
@@ -22,68 +22,17 @@ import attr
 from attr.validators import instance_of as is_a
 from attr.validators import optional
 
-from rnacentral_pipeline.databases.data import regions
+from rnacentral_pipeline.databases.data import Database, regions
 
 
 def lookup_databases(raw):
-    lookup = {
-        "ENA": "ENA",
-        "RFAM": "Rfam",
-        "SRPDB": "SRPDB",
-        "MIRBASE": "miRBase",
-        "VEGA": "VEGA",
-        "TMRNA_WEB": "tmRNA Website",
-        "LNCRNADB": "lncRNAdb",
-        "GTRNADB": "GtRNAdb",
-        "REFSEQ": "RefSeq",
-        "RDP": "RDP",
-        "PDBE": "PDBe",
-        "SNOPY": "snOPY",
-        "GREENGENES": "Greengenes",
-        "TAIR": "TAIR",
-        "WORMBASE": "WormBase",
-        "SGD": "SGD",
-        "SILVA": "SILVA",
-        "POMBASE": "PomBase",
-        "DICTYBASE": "dictyBase",
-        "LNCIPEDIA": "LNCipedia",
-        "NONCODE": "NONCODE",
-        "MODOMICS": "Modomics",
-        "HGNC": "HGNC",
-        "FLYBASE": "FlyBase",
-        "ENSEMBL": "Ensembl",
-        "GENCODE": "GENCODE",
-        "MGI": "MGI",
-        "RGD": "RGD",
-        "TARBASE": "TarBase",
-        "ZWD": "ZWD",
-        "ENSEMBL_PLANTS": "Ensembl Plants",
-        "LNCBASE": "LncBase",
-        "LNCBOOK": "LncBook",
-        "ENSEMBL_METAZOA": "Ensembl Metazoa",
-        "ENSEMBL_PROTISTS": "Ensembl Protists",
-        "ENSEMBL_FUNGI": "Ensembl Fungi",
-        "SNODB": "snoDB",
-        "5SRRNADB": "5SrRNAdb",
-        "MIRGENEDB": "MirGeneDB",
-        "MALACARDS": "MalaCards",
-        "GENECARDS": "GeneCards",
-        "INTACT": "IntAct",
-        "SNORNADB": "snoRNA Database",
-        "ZFIN": "ZFIN",
-        "CRW": "CRW",
-        "PIRBASE": "piRBase",
-        "ENSEMBL_GENCODE": "Ensembl/GENCODE",
-        "PSICQUIC": "PSICQUIC",
-        "RIBOVISION": "RiboVision",
-        "PLNCDB": "PLncDB",
-        "EXPRESSION_ATLAS": "Expression Atlas",
-        "RIBOCENTRE": "Ribocentre",
-        "EVLNCRNAS": "EVLncRNAs",
-        "REDIPORTAL": "REDIPortal",
-        "MGNIFY": "MGnify",
-    }
-    return [lookup[d] for d in raw if d]
+    databases = []
+    for db in raw:
+        found = Database.lookup(db)
+        if not found:
+            raise ValueError(f"Failed to lookup database {db}")
+        databases.append(found.pretty())
+    return databases
 
 
 def clean_databases(raw):

--- a/rnacentral_pipeline/rnacentral/ftp_export/coordinates/data.py
+++ b/rnacentral_pipeline/rnacentral/ftp_export/coordinates/data.py
@@ -83,7 +83,7 @@ def lookup_databases(raw):
         "REDIPORTAL": "REDIPortal",
         "MGNIFY": "MGnify",
     }
-    return [lookup[d] for d in raw]
+    return [lookup[d] for d in raw if d]
 
 
 def clean_databases(raw):


### PR DESCRIPTION
Update the logic for genome coordiante export to correctly deal with the new structure for coordinates. Previously, this would not export all sequences as it had a `JOIN` rather than a `LEFT JOIN` to fetch the mapped accessions. This lead to having only the coordintes which are provided, not all of them. This should be fixed now.