### PR TITLE
Tarbase update

### DIFF
--- a/config/databases.config
+++ b/config/databases.config
@@ -202,7 +202,12 @@ params {
     }
 
     tarbase {
-      remote = '/nfs/production/agb/rnacentral/provided-data/tarbase/TarBase8-corrected.json'
+      remotes = [
+        'https://dianalab.e-ce.uth.gr/tarbasev9/data/Homo_sapiens_TarBase-v9.tsv.gz',
+        'https://dianalab.e-ce.uth.gr/tarbasev9/data/Mus_musculus_TarBase-v9.tsv.gz',
+        'https://dianalab.e-ce.uth.gr/tarbasev9/data/Viral_species_TarBase-v9.tsv.gz',
+        'https://dianalab.e-ce.uth.gr/tarbasev9/data/Other_species_TarBase-v9.tsv.gz'
+      ]
     }
 
     zfin {

--- a/data/tarbase/tarbase.tsv
+++ b/data/tarbase/tarbase.tsv
@@ -1,0 +1,2 @@
+species	mirna_name	mirna_id	gene_name	gene_id	gene_location	transcript_name	transcript_id	chromosome	start	end	strand	experimental_method	regulation	tissue	cell_line	article_pubmed_id	confidence	interaction_group	cell_type	microt_score	comment
+Homo sapiens	hsa-miR-103a-3p	MIMAT0000101	C1orf112	ENSG00000000460	CDS	NA	ENST00000286031	chr1	169823429	169823441	+	PAR-CLIP	Negative	Cervix	TZMBL	23592263	1	primary	CD4+ T cells	0.37	NA

--- a/pytest.ini
+++ b/pytest.ini
@@ -41,4 +41,5 @@ markers =
   r2dt: Tests for r2dt related functions
   so: tests for the sequence ontology
   silva: tests for silva
+  tarbase: tests for tarbase
   trna: Trna related tests

--- a/rnacentral_pipeline/cli/tarbase.py
+++ b/rnacentral_pipeline/cli/tarbase.py
@@ -21,6 +21,11 @@ from rnacentral_pipeline.databases.generic import parser as generic
 from rnacentral_pipeline.writers import entry_writer
 
 
+def _write_entries(entries, output):
+    with entry_writer(Path(output)) as writer:
+        writer.write(entries)
+
+
 @click.group("tarbase")
 def cli():
     """
@@ -40,5 +45,7 @@ def process_json_schema(json_file, output):
     This parses our JSON schema files to produce the importable CSV files.
     """
     entries = generic.parse(json_file)
+    _write_entries(entries, output)
+
     with entry_writer(Path(output)) as writer:
         writer.write(entries)

--- a/rnacentral_pipeline/cli/tarbase.py
+++ b/rnacentral_pipeline/cli/tarbase.py
@@ -18,6 +18,7 @@ from pathlib import Path
 import click
 
 from rnacentral_pipeline.databases.generic import parser as generic
+from rnacentral_pipeline.databases.tarbase import parser as specific
 from rnacentral_pipeline.writers import entry_writer
 
 
@@ -47,5 +48,15 @@ def process_json_schema(json_file, output):
     entries = generic.parse(json_file)
     _write_entries(entries, output)
 
-    with entry_writer(Path(output)) as writer:
-        writer.write(entries)
+
+@cli.command("parse-tsv")
+@click.argument("tsv_file", type=click.File("r"))
+@click.argument(
+    "output",
+    default=".",
+    type=click.Path(writable=True, dir_okay=True, file_okay=False),
+)
+def process_tsv_file(tsv_file, output):
+    print(dir(tsv_file))
+    entries = specific.parse(tsv_file.name)
+    _write_entries(entries, output)

--- a/rnacentral_pipeline/cli/tarbase.py
+++ b/rnacentral_pipeline/cli/tarbase.py
@@ -57,6 +57,5 @@ def process_json_schema(json_file, output):
     type=click.Path(writable=True, dir_okay=True, file_okay=False),
 )
 def process_tsv_file(tsv_file, output):
-    print(dir(tsv_file))
     entries = specific.parse(tsv_file.name)
     _write_entries(entries, output)

--- a/rnacentral_pipeline/cli/tarbase.py
+++ b/rnacentral_pipeline/cli/tarbase.py
@@ -17,14 +17,8 @@ from pathlib import Path
 
 import click
 
-from rnacentral_pipeline.databases.generic import parser as generic
 from rnacentral_pipeline.databases.tarbase import parser as specific
 from rnacentral_pipeline.writers import entry_writer
-
-
-def _write_entries(entries, output):
-    with entry_writer(Path(output)) as writer:
-        writer.write(entries)
 
 
 @click.group("tarbase")
@@ -35,21 +29,6 @@ def cli():
 
 
 @cli.command("parse")
-@click.argument("json_file", type=click.File("r"))
-@click.argument(
-    "output",
-    default=".",
-    type=click.Path(writable=True, dir_okay=True, file_okay=False),
-)
-def process_json_schema(json_file, output):
-    """
-    This parses our JSON schema files to produce the importable CSV files.
-    """
-    entries = generic.parse(json_file)
-    _write_entries(entries, output)
-
-
-@cli.command("parse-tsv")
 @click.argument("tsv_file", type=click.File("r"))
 @click.argument(
     "output",
@@ -58,4 +37,5 @@ def process_json_schema(json_file, output):
 )
 def process_tsv_file(tsv_file, output):
     entries = specific.parse(tsv_file.name)
-    _write_entries(entries, output)
+    with entry_writer(Path(output)) as writer:
+        writer.write(entries)

--- a/rnacentral_pipeline/databases/tarbase/parser.py
+++ b/rnacentral_pipeline/databases/tarbase/parser.py
@@ -1,0 +1,148 @@
+import os
+
+import polars as pl
+import psycopg2 as pg
+from psycopg2.extras import execute_batch
+
+from rnacentral_pipeline.databases.data.entry import Entry
+from rnacentral_pipeline.databases.data.related import (
+    RelatedCoordinate,
+    RelatedEvidence,
+    RelatedSequence,
+)
+from rnacentral_pipeline.databases.helpers import phylogeny as phy
+
+
+def build_entry(row):
+    primary_id = row["mirna_id"]
+    ## Use this accession form to match existing accessions
+    accession = f"TARBASE:{row['mirna_id']}"
+
+    database = "TARBASE"
+
+    regions = (
+        []
+    )  # The genome coords provided by tarbase are for the PROTEIN gene, not miRNA. Give empty region?
+    rna_type = "SO:0000276"  # miRNA - tarBase is all miRNA
+
+    ## This takes you to the specific search results for the interation on this row
+    url = f"https://dianalab.e-ce.uth.gr/tarbasev9/interactions?gene={row['gene_name']}&mirna={row['mirna_name']}"
+
+    ## Not clear how to set this here
+    seq_version = 1
+
+    related_sequences = []
+    for (
+        related_gene,
+        exp_meth,
+    ) in zip(row["gene_id"], row["experimental_method"]):
+
+        evidence = RelatedEvidence(methods=[exp_meth])
+
+        related_sequences.append(
+            RelatedSequence(
+                sequence_id=related_gene,
+                relationship="target_protein",
+                evidence=evidence,
+            )
+        )
+
+    ## Make this as minimal as possible, don't fill everything
+    ent = Entry(
+        primary_id=primary_id,
+        accession=accession,
+        ncbi_tax_id=row["taxid"],
+        database=database,
+        sequence=row["sequence"].replace("U", "T"),
+        regions=regions,
+        rna_type=rna_type,
+        url=url,
+        seq_version=seq_version,
+        optional_id=row["mirna_name"],
+        description=f"{row['species']} ({phy.common_name(row['taxid']) }) {row['mirna_name']}",
+        note_data={"url": url},
+        xref_data={},
+        related_sequences=related_sequences,
+    )
+
+    return ent
+
+
+def parse(filepath):
+    """
+    Parse the provided tsv file into entry objects we can put in the database
+
+    Some notes on the TSV:
+    - mirna_name and mirna_id are the miRNA identifiers we will hold and should look for
+    - gene_name, gene_id, transcript_name and transcript_id all reter to the protein coding gene
+        targeted by the miRNA
+
+    """
+    data = pl.read_csv(filepath, separator="\t", null_values=["NA"]).unique()
+
+    species_mentioned = tuple(
+        data.select(pl.col("species").unique()).get_column("species").to_list()
+    )
+
+    taxa_query = """
+    SELECT name as species, id as taxid FROM rnc_taxonomy
+    WHERE name IN %(names)s
+    AND replaced_by IS NULL
+    """
+
+    ## Have to use a psycopg connection to allow it to mogrify names into the query
+    conn = pg.connect(os.getenv("PGDATABASE"))
+    cur = conn.cursor()
+    taxa_results = pl.read_database(
+        query=taxa_query,
+        connection=conn,
+        execute_options={"parameters": {"names": species_mentioned}},
+    )
+
+    data = data.join(taxa_results, on="species", how="left")
+
+    grouped_data = data.group_by("mirna_id", maintain_order=True).agg(
+        pl.col("mirna_name").first(),
+        pl.col("gene_id"),
+        pl.col("gene_name"),
+        pl.col("experimental_method"),
+        pl.col("article_pubmed_id"),
+        pl.col("taxid").first(),
+        pl.col("species").first(),
+    )
+
+    accessions = [
+        (f"MIRBASE:{mirna_id}",)
+        for mirna_id in grouped_data.get_column("mirna_id").to_list()
+    ]
+    cur.execute("CREATE TEMPORARY TABLE temp_accessions_tarbase (ac TEXT)")
+    execute_batch(cur, "INSERT INTO temp_accessions_tarbase VALUES (%s)", accessions)
+
+    sequence_query = """
+    WITH temp_xref_data AS (
+        SELECT upi, xref.ac FROM
+        xref JOIN temp_accessions_tarbase ON xref.ac = temp_accessions_tarbase.ac
+        WHERE deleted = 'N'
+    )
+    SELECT
+        SPLIT_PART(ac, ':', 2) AS mirna_id,
+        COALESCE(seq_short, seq_long) AS sequence
+    FROM rna
+    JOIN temp_xref_data ON rna.upi = temp_xref_data.upi
+    """
+
+    sequence_results = pl.read_database(
+        query=sequence_query,
+        connection=conn,
+        execute_options={
+            "parameters": {
+                "accessions": accessions,
+            }
+        },
+    )
+
+    grouped_data = grouped_data.join(sequence_results, on="mirna_id")
+
+    entries = [build_entry(r) for r in grouped_data.iter_rows(named=True)]
+
+    return entries

--- a/rnacentral_pipeline/databases/tarbase/parser.py
+++ b/rnacentral_pipeline/databases/tarbase/parser.py
@@ -1,4 +1,5 @@
 import os
+import typing as ty
 
 import polars as pl
 import psycopg2 as pg
@@ -9,7 +10,7 @@ from rnacentral_pipeline.databases.data.related import RelatedEvidence, RelatedS
 from rnacentral_pipeline.databases.helpers import phylogeny as phy
 
 
-def build_entry(row):
+def build_entry(row: ty.Dict[str, str]) -> Entry:
     primary_id = row["mirna_id"]
     ## Use this accession form to match existing accessions
     accession = f"TARBASE:{row['mirna_id']}"
@@ -54,7 +55,7 @@ def build_entry(row):
     return ent
 
 
-def parse(filepath):
+def parse(filepath: str) -> ty.List[Entry]:
     """
     Parse the provided tsv file into entry objects we can put in the database
 

--- a/rnacentral_pipeline/databases/tarbase/parser.py
+++ b/rnacentral_pipeline/databases/tarbase/parser.py
@@ -11,7 +11,7 @@ from rnacentral_pipeline.databases.helpers import phylogeny as phy
 
 
 def build_entry(row: ty.Dict[str, str]) -> Entry:
-    primary_id = row["mirna_id"]
+    primary_id = row["mirna_name"]
     ## Use this accession form to match existing accessions
     accession = f"TARBASE:{row['mirna_name']}"
 
@@ -45,7 +45,7 @@ def build_entry(row: ty.Dict[str, str]) -> Entry:
         rna_type="SO:0000276",  # miRNA - tarBase is all miRNA
         url=url,
         seq_version=1,
-        optional_id=row["mirna_name"],
+        optional_id=row["mirna_id"],
         description=f"{row['species']} ({phy.common_name(int(row['taxid'])) }) {row['mirna_name']}",
         note_data={"url": url},
         xref_data={},

--- a/rnacentral_pipeline/databases/tarbase/parser.py
+++ b/rnacentral_pipeline/databases/tarbase/parser.py
@@ -37,7 +37,7 @@ def build_entry(row):
     ent = Entry(
         primary_id=primary_id,
         accession=accession,
-        ncbi_tax_id=row["taxid"],
+        ncbi_tax_id=int(row["taxid"]),
         database="TARBASE",
         sequence=row["sequence"].replace("U", "T"),
         regions=[],
@@ -45,7 +45,7 @@ def build_entry(row):
         url=url,
         seq_version=1,
         optional_id=row["mirna_name"],
-        description=f"{row['species']} ({phy.common_name(row['taxid']) }) {row['mirna_name']}",
+        description=f"{row['species']} ({phy.common_name(int(row['taxid'])) }) {row['mirna_name']}",
         note_data={"url": url},
         xref_data={},
         related_sequences=related_sequences,

--- a/rnacentral_pipeline/databases/tarbase/parser.py
+++ b/rnacentral_pipeline/databases/tarbase/parser.py
@@ -18,18 +18,8 @@ def build_entry(row):
     ## Use this accession form to match existing accessions
     accession = f"TARBASE:{row['mirna_id']}"
 
-    database = "TARBASE"
-
-    regions = (
-        []
-    )  # The genome coords provided by tarbase are for the PROTEIN gene, not miRNA. Give empty region?
-    rna_type = "SO:0000276"  # miRNA - tarBase is all miRNA
-
     ## This takes you to the specific search results for the interation on this row
     url = f"https://dianalab.e-ce.uth.gr/tarbasev9/interactions?gene={row['gene_name']}&mirna={row['mirna_name']}"
-
-    ## Not clear how to set this here
-    seq_version = 1
 
     related_sequences = []
     for (
@@ -41,7 +31,7 @@ def build_entry(row):
 
         related_sequences.append(
             RelatedSequence(
-                sequence_id=related_gene,
+                sequence_id=f"ENSEMBL:{related_gene}",
                 relationship="target_protein",
                 evidence=evidence,
             )
@@ -52,12 +42,12 @@ def build_entry(row):
         primary_id=primary_id,
         accession=accession,
         ncbi_tax_id=row["taxid"],
-        database=database,
+        database="TARBASE",
         sequence=row["sequence"].replace("U", "T"),
-        regions=regions,
-        rna_type=rna_type,
+        regions=[],
+        rna_type="SO:0000276",  # miRNA - tarBase is all miRNA
         url=url,
-        seq_version=seq_version,
+        seq_version=1,
         optional_id=row["mirna_name"],
         description=f"{row['species']} ({phy.common_name(row['taxid']) }) {row['mirna_name']}",
         note_data={"url": url},

--- a/rnacentral_pipeline/databases/tarbase/parser.py
+++ b/rnacentral_pipeline/databases/tarbase/parser.py
@@ -13,10 +13,10 @@ from rnacentral_pipeline.databases.helpers import phylogeny as phy
 def build_entry(row: ty.Dict[str, str]) -> Entry:
     primary_id = row["mirna_id"]
     ## Use this accession form to match existing accessions
-    accession = f"TARBASE:{row['mirna_id']}"
+    accession = f"TARBASE:{row['mirna_name']}"
 
     ## This takes you to the specific search results for the interation on this row
-    url = f"https://dianalab.e-ce.uth.gr/tarbasev9/interactions?gene={row['gene_name']}&mirna={row['mirna_name']}"
+    url = f"https://dianalab.e-ce.uth.gr/tarbasev9/interactions?gene={row['gene_name'][0]}&mirna={row['mirna_name']}"
 
     related_sequences = []
     for (

--- a/rnacentral_pipeline/databases/tarbase/parser.py
+++ b/rnacentral_pipeline/databases/tarbase/parser.py
@@ -5,11 +5,7 @@ import psycopg2 as pg
 from psycopg2.extras import execute_batch
 
 from rnacentral_pipeline.databases.data.entry import Entry
-from rnacentral_pipeline.databases.data.related import (
-    RelatedCoordinate,
-    RelatedEvidence,
-    RelatedSequence,
-)
+from rnacentral_pipeline.databases.data.related import RelatedEvidence, RelatedSequence
 from rnacentral_pipeline.databases.helpers import phylogeny as phy
 
 

--- a/tests/databases/tarbase/test_parse_tsv.py
+++ b/tests/databases/tarbase/test_parse_tsv.py
@@ -1,0 +1,50 @@
+import pytest
+
+from rnacentral_pipeline.databases.data.entry import Entry
+from rnacentral_pipeline.databases.data.related import (
+    RelatedCoordinate,
+    RelatedEvidence,
+    RelatedSequence,
+)
+from rnacentral_pipeline.databases.tarbase.parser import parse
+
+
+@pytest.mark.tarbase
+def test_tarbase_tsv_parse_existing():
+    """
+    Try to parse tsv for an existing accession and get the data we expect
+    Take interation btwn hsa-miR-103a-3p and ENSG00000000460
+    """
+
+    # Accession line: "TARBASE:hsa-miR-103a-3p","","1","1","24","ncRNA","","TARBASE","hsa-miR-103a-3p","","Homo sapiens (human) hsa-miR-103a-3p","","","","","TARBASE:hsa-miR-103a-3p","","","","miRNA","{""url"": ""http://carolina.imis.athena-innovation.gr/diana_tools/web/index.php?r=tarbasev8%2Findex&miRNAs%5B%5D=hsa-miR-103a-3p""}","","","{}","SO:0000276","http://carolina.imis.athena-innovation.gr/diana_tools/web/index.php?r=tarbasev8%2Findex&miRNAs%5B%5D=hsa-miR-103a-3p"
+    # Related Seq: "TARBASE:hsa-miR-103a-3p","ENSEMBL:ENSG00000000460","target_protein","{""Microarrays""}"
+
+    related_sequences = [
+        RelatedSequence(
+            sequence_id=f"ENSEMBL:ENSG00000000460",
+            relationship="target_protein",
+            evidence=RelatedEvidence(methods=["PAR-CLIP"]),
+        )
+    ]
+    ## NB: the method changed between version 8 & 9: Microarrays -> PAR-CLIP
+    url = "https://dianalab.e-ce.uth.gr/tarbasev9/interactions?gene=C1orf112&mirna=hsa-miR-103a-3p"
+    correct_entry = Entry(
+        primary_id="MIMAT0000101",
+        accession="TARBASE:hsa-miR-103a-3p",
+        ncbi_tax_id=9606,
+        database="TARBASE",
+        sequence="AGCAGCATTGTACAGGGCTATGA",
+        regions=[],  ## Don't create regions for protein target
+        rna_type="SO:0000276",
+        url=url,
+        seq_version=1,
+        optional_id="hsa-miR-103a-3p",
+        description="Homo sapiens (human) hsa-miR-103a-3p",
+        note_data={"url": url},
+        xref_data={},
+        related_sequences=related_sequences,
+    )
+
+    parsed_entry = parse("data/tarbase/tarbase.tsv")[0]
+
+    assert parsed_entry == correct_entry

--- a/tests/databases/tarbase/test_parse_tsv.py
+++ b/tests/databases/tarbase/test_parse_tsv.py
@@ -29,7 +29,7 @@ def test_tarbase_tsv_parse_existing():
     ## NB: the method changed between version 8 & 9: Microarrays -> PAR-CLIP
     url = "https://dianalab.e-ce.uth.gr/tarbasev9/interactions?gene=C1orf112&mirna=hsa-miR-103a-3p"
     correct_entry = Entry(
-        primary_id="MIMAT0000101",
+        primary_id="hsa-miR-103a-3p",
         accession="TARBASE:hsa-miR-103a-3p",
         ncbi_tax_id=9606,
         database="TARBASE",
@@ -38,7 +38,7 @@ def test_tarbase_tsv_parse_existing():
         rna_type="SO:0000276",
         url=url,
         seq_version=1,
-        optional_id="hsa-miR-103a-3p",
+        optional_id="MIMAT0000101",
         description="Homo sapiens (human) hsa-miR-103a-3p",
         note_data={"url": url},
         xref_data={},

--- a/workflows/databases/tarbase.nf
+++ b/workflows/databases/tarbase.nf
@@ -28,6 +28,6 @@ process parse {
   path('*.csv')
 
   """
-  rnac tarbase parse-tsv ${tsv_file} .
+  rnac tarbase parse ${tsv_file} .
   """
 }

--- a/workflows/databases/tarbase.nf
+++ b/workflows/databases/tarbase.nf
@@ -1,11 +1,33 @@
-process tarbase {
+workflow tarbase {
+  emit: data
+  remotes = channel.of( params.databases.tarbase.remotes )
+  remotes | fetch | parse | set { data }
+}
+
+process fetch {
   when: { params.databases.tarbase.run }
+
+  input:
+  val remote
+  output:
+  path('*.tsv')
+
+  """
+  wget -O tarbase.tsv.gz ${remote}
+  gzip -d tarbase.tsv.gz
+  """
+}
+
+process parse {
+  when: { params.databases.tarbase.run }
+
+  input:
+  path tsv_file
 
   output:
   path('*.csv')
 
   """
-  cp ${params.databases.tarbase.remote} tarbase.json
-  rnac tarbase parse tarbase.json .
+  rnac tarbase parse-tsv ${tsv_file} .
   """
 }


### PR DESCRIPTION
Tarbase v9 no longer uses the generic json loader, so we need to parse their tsv ourselves. 

This PR uses polars to simplify processing, including using polars to query the database and extract the necessary information (e.g. sequence) to build accessions.

The way I've written this uses SQL queries from python. I don't know if that 's something I should have avoided, but it does work, and fairly fast. The maximum number of queries is probably 8 (2 per file here: https://dianalab.e-ce.uth.gr/tarbasev9/downloads), with the majority being quite small. We would have at most 4 concurrent queries, so I think it will be ok

TODO: nextflow stuff