### PR TITLE
Find the missing RNAs reported by GeneCArds

### DIFF
--- a/rnacentral_pipeline/databases/tarbase/parser.py
+++ b/rnacentral_pipeline/databases/tarbase/parser.py
@@ -129,14 +129,23 @@ def parse(filepath: str) -> ty.List[Entry]:
 
     data = data.join(taxa_results, on="species", how="left").drop_nulls("taxid")
 
-    grouped_data = data.group_by("mirna_id", maintain_order=True).agg(
-        pl.col("mirna_name").first(),
-        pl.col("gene_id"),
-        pl.col("gene_name"),
-        pl.col("experimental_method"),
-        pl.col("article_pubmed_id"),
-        pl.col("taxid").first(),
-        pl.col("species").first(),
+    grouped_data = (
+        data.group_by("mirna_id", maintain_order=True)
+        .agg(
+            pl.col("mirna_name").first(),
+            pl.col("gene_id"),
+            pl.col("gene_name"),
+            pl.col("experimental_method"),
+            pl.col("article_pubmed_id"),
+            pl.col("taxid").first(),
+            pl.col("species").first(),
+        )
+        .with_columns(
+            pl.col("gene_id").list.unique(maintain_order=True),
+            pl.col("gene_name").list.unique(maintain_order=True),
+            pl.col("experimental_method").list.unique(maintain_order=True),
+            pl.col("article_pubmed_id").list.unique(maintain_order=True),
+        )
     )
 
     accessions = [

--- a/rnacentral_pipeline/rnacentral/ftp_export/coordinates/data.py
+++ b/rnacentral_pipeline/rnacentral/ftp_export/coordinates/data.py
@@ -79,8 +79,9 @@ class Region(object):
         }
         if not metadata["providing_databases"]:
             if not raw["was_mapped"]:
-                print(raw)
-                raise ValueError("No providing database for an unmapped region!")
+                raise ValueError(
+                    f"No providing database for an unmapped region!\n{raw}"
+                )
             del metadata["providing_databases"]
 
         return cls(

--- a/rnacentral_pipeline/rnacentral/ftp_export/coordinates/data.py
+++ b/rnacentral_pipeline/rnacentral/ftp_export/coordinates/data.py
@@ -28,6 +28,8 @@ from rnacentral_pipeline.databases.data import Database, regions
 def lookup_databases(raw):
     databases = []
     for db in raw:
+        if db is None:
+            continue
         found = Database.lookup(db)
         if not found:
             raise ValueError(f"Failed to lookup database {db}")
@@ -76,6 +78,9 @@ class Region(object):
             "databases": clean_databases(raw["databases"]),
         }
         if not metadata["providing_databases"]:
+            if not raw["was_mapped"]:
+                print(raw)
+                raise ValueError("No providing database for an unmapped region!")
             del metadata["providing_databases"]
 
         return cls(


### PR DESCRIPTION
Between releases 23 and 24, a large number of RNAs went missing from our genome coordinate FTP exports. GeneCards reported this for our human coordinates, and gave this table that summarises what went missing:

| Database  | Previous Count | Current Count | Percentage Decrease |
|------------|----------------|---------------|---------------------|
| ENA       | 869,516       | 483,656      | 44%                |
| Rfam      | 47,153        | 7,229        | 84%                |
| PDBe      | 3,387         | 102          | 96%                |
| lncRNAdb  | 222           | 55           | 75%                |
| SRPDB     | 34            | 2            | 94%                |
| CRW       | 173           | 0            | 100%               |
| RiboVision | 76            | 0            | 100%               |
| 5SrRNAdb  | 32            | 0            | 100%               |

This amounts to a little over 400k sequences that have gone missing.

One possible reason is badly handled export of mapped vs recieved coordinates. When an expert db gives us coordinates, we import them and they get associated with the database when we export them, and have `source=expert-database` in the gff. Mapped sequences should have `source=alignment` in the gff, and inspecting the release 24 gff file - there are 0 aligned sequences, which is clearly not right.

I've modified how we handle the mapped sequences in the gff writer so that we only throw an exception if :
1. The database associated with a region genuinely cannot be looked up (mis-spelled or whatever)
2. We do not have a providing database for a provided sequence

This is able to produce gff files that contain ~273k aligned sequences that were previously missing. I think this is part of the missing data, but we still need to find ~100k more, so this is not completely finished yet.