### PR TITLE
Remove explicit reference to xref partition and use declarative parti…

### DIFF
--- a/rnacentral_pipeline/databases/ribovision/parser.py
+++ b/rnacentral_pipeline/databases/ribovision/parser.py
@@ -16,14 +16,13 @@ limitations under the License.
 import re
 import typing as ty
 
-from bs4 import BeautifulSoup
 import psycopg2
 import psycopg2.extras
+from bs4 import BeautifulSoup
 from pypika import Query, Table
 from pypika import functions as fn
 
 from rnacentral_pipeline.databases import data
-
 
 PATTERN = re.compile(r"^(.+?)\s+\((.+?)\)\s+(http.+?)\s*$")
 
@@ -47,7 +46,7 @@ def extract_mapping(raw: ty.IO) -> ty.Dict[ty.Tuple[str, str], ty.Tuple[str, str
 
 def build_query(pdb_id: str, chain_id: str) -> str:
     rna = Table("rna")
-    xref = Table("xref_p11_not_deleted")
+    xref = Table("xref")
     pre = Table("rnc_rna_precomputed")
     acc = Table("rnc_accessions")
 
@@ -65,7 +64,12 @@ def build_query(pdb_id: str, chain_id: str) -> str:
         .on(rna.upi == xref.upi)
         .join(acc)
         .on(acc.accession == xref.ac)
-        .where((acc.external_id == pdb_id) & (acc.optional_id == chain_id))
+        .where(
+            (acc.external_id == pdb_id)
+            & (acc.optional_id == chain_id)
+            & (xref.dbid == 11)  # Added: was implicit in partition
+            & (xref.deleted == "N")  # Added: was implicit in partition
+        )
     )
     return str(query)
 


### PR DESCRIPTION
The database has for a long time had a partitioning scheme on the xref table based on inheritance and a big trigger function. This made adding new databases to RNAcentral more painful than it needed to be.

This PR accompanies structural changes in the database to enable declarative partitioning, and get rid of most of the manual modification of the trigger function that was previously required. 

The only change in the code was one reference to a specific partiton, which we can get rid of by adding a couple more conditions to the query that were implicit by using the partition. 

This whole change pending a test import into the test database, and testing website deployment from there before I synchronise the changes in the PRO database, hence draft PR