### PR TITLE
Experimental/ena optimizations

### DIFF
--- a/config/databases.config
+++ b/config/databases.config
@@ -53,13 +53,9 @@ params {
       remote = '/nfs/ftp/public/databases/ena/non-coding/snapshot_latest'
       max_sequences = 50000
       // wgs/, tls/ and tsa/ each have thousands of project subdirs; rsync them
-      // in batches per task so the fetch fans out across the cluster instead of
-      // one giant serial NFS walk. Batches are packed by directory inode size
-      // (a cheap proxy for entry count) up to this many bytes, so a few huge
-      // subdirs like wgs/jap don't make some tasks far heavier than others.
-      // Bigger budget => fewer, heavier tasks. ~250 MB ≈ a couple hundred
-      // average subdirs per task; tune to taste.
-      subdir_batch_bytes = 250000000
+      // in batches of this many per task so the fetch fans out across the
+      // cluster instead of one giant serial NFS walk.
+      subdir_batch_size = 100
     }
 
     ensembl {

--- a/config/databases.config
+++ b/config/databases.config
@@ -52,6 +52,10 @@ params {
     ena {
       remote = '/nfs/ftp/public/databases/ena/non-coding/snapshot_latest'
       max_sequences = 50000
+      // wgs/, tls/ and tsa/ each have thousands of project subdirs; rsync them
+      // in batches of this many per task so the fetch fans out across the
+      // cluster instead of one giant serial NFS walk.
+      subdir_batch_size = 200
     }
 
     ensembl {

--- a/config/databases.config
+++ b/config/databases.config
@@ -53,9 +53,13 @@ params {
       remote = '/nfs/ftp/public/databases/ena/non-coding/snapshot_latest'
       max_sequences = 50000
       // wgs/, tls/ and tsa/ each have thousands of project subdirs; rsync them
-      // in batches of this many per task so the fetch fans out across the
-      // cluster instead of one giant serial NFS walk.
-      subdir_batch_size = 200
+      // in batches per task so the fetch fans out across the cluster instead of
+      // one giant serial NFS walk. Batches are packed by directory inode size
+      // (a cheap proxy for entry count) up to this many bytes, so a few huge
+      // subdirs like wgs/jap don't make some tasks far heavier than others.
+      // Bigger budget => fewer, heavier tasks. ~250 MB ≈ a couple hundred
+      // average subdirs per task; tune to taste.
+      subdir_batch_bytes = 250000000
     }
 
     ensembl {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,8 @@ dependencies = [
     "datasets>=3.5.0",
     "fastjsonschema>=2.21.2",
     "stopfree>=0.2.4",
+    "fastcrc>=0.3.5",
+    "crcmod>=1.7",
 ]
 
 
@@ -60,6 +62,8 @@ dev = [
     "pytest>=7.2.0",
     "maturin>=1.10",
     "line-profiler>=5.0.0",
+    "mypy>=1.20.2",
+    "crcmod>=1.7",
 ]
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,6 @@ dependencies = [
     "datasets>=3.5.0",
     "fastjsonschema>=2.21.2",
     "stopfree>=0.2.4",
-    "fastcrc>=0.3.5",
     "crcmod>=1.7",
 ]
 

--- a/rnacentral_pipeline/cli/ena.py
+++ b/rnacentral_pipeline/cli/ena.py
@@ -58,28 +58,28 @@ def process_ena(
     builder.with_ribovore(Path(ribovore_path), Path(model_lengths))
     builder.with_tpa(Path(mapping_file))
     builder.with_dr(ena_file)
-    ctx = builder.context()
-    entries = parser.parse_with_context(ctx, ena_file)
-    try:
-        with entry_writer(Path(output)) as writer:
-            writer.write(entries)
-    except ValueError:
-        print("No entries could be written for one of the parsed ENA files.")
-        print("Sending warning to slack, but carrying on")
+    with builder.context() as ctx:
+        entries = parser.parse_with_context(ctx, ena_file)
+        try:
+            with entry_writer(Path(output)) as writer:
+                writer.write(entries)
+        except ValueError:
+            print("No entries could be written for one of the parsed ENA files.")
+            print("Sending warning to slack, but carrying on")
 
-        # Dump this again to attach to the report
+            # Dump this again to attach to the report
+            ctx.dump_counts(Path(counts))
+
+            message = f"No entries could be written for ENA file {ena_file}\n"
+            message += "This may be correct, but you should check\n"
+            message += f"Working directory: {os.getcwd()}\n"
+            message += "Ribotyper log:\n"
+            message += open(
+                Path(ribovore_path) / "ribotyper-results.ribotyper.log", "r"
+            ).read()
+            message += "\n\nContext counts:\n"
+            message += open(Path(counts), "r").read()
+
+            send_notification("ENA parsing error", message)
+
         ctx.dump_counts(Path(counts))
-
-        message = f"No entries could be written for ENA file {ena_file}\n"
-        message += "This may be correct, but you should check\n"
-        message += f"Working directory: {os.getcwd()}\n"
-        message += "Ribotyper log:\n"
-        message += open(
-            Path(ribovore_path) / "ribotyper-results.ribotyper.log", "r"
-        ).read()
-        message += "\n\nContext counts:\n"
-        message += open(Path(counts), "r").read()
-
-        send_notification("ENA parsing error", message)
-
-    ctx.dump_counts(Path(counts))

--- a/rnacentral_pipeline/databases/data/entry.py
+++ b/rnacentral_pipeline/databases/data/entry.py
@@ -49,7 +49,7 @@ FEATURE_TYPE_RNAS = set(
 )
 
 
-@attr.s(frozen=True)
+@attr.s(frozen=True, slots=True)
 class Entry:
     """
     This represents an RNAcentral entry that will be imported into the
@@ -60,20 +60,19 @@ class Entry:
     """
 
     # Also known as external_id
-    primary_id: str = attr.ib(validator=is_a(str), converter=str)
-    accession: str = attr.ib(validator=is_a(str), converter=str)
+    primary_id: str = attr.ib(validator=is_a(str))
+    accession: str = attr.ib(validator=is_a(str))
     ncbi_tax_id: int = attr.ib(validator=is_a(int))
     database: str = attr.ib(
         validator=is_a(str),
-        converter=lambda s: str(s.upper()),
     )
-    sequence: str = attr.ib(validator=is_a(str), converter=str)
+    sequence: str = attr.ib(validator=is_a(str))
     regions: ty.List[SequenceRegion] = attr.ib(validator=is_a(list))
     rna_type: str = attr.ib(
         validator=utils.matches_pattern(utils.SO_PATTERN),
         converter=utils.as_so_term,
     )
-    url: str = attr.ib(validator=is_a(str), converter=str)
+    url: str = attr.ib(validator=is_a(str))
     seq_version: str = attr.ib(
         validator=and_(is_a(str), utils.matches_pattern(r"^\d+$")),
         converter=lambda r: str(int(float(r))),

--- a/rnacentral_pipeline/databases/data/entry.py
+++ b/rnacentral_pipeline/databases/data/entry.py
@@ -238,12 +238,10 @@ class Entry:
             LOGGER.warn("%s is too long (%s)", self.accession, length)
             return False
 
-        counts = Counter(self.sequence)
-        fraction = float(counts.get("N", 0)) / float(len(self.sequence))
+        counts = self.sequence.count("N")
+        fraction = float(counts) / float(length)
         if fraction > 0.1:
-            LOGGER.warn(
-                "%s has too many (%i/%i) N's", self.accession, counts["N"], length
-            )
+            LOGGER.warn("%s has too many (%i/%i) N's", self.accession, counts, length)
             return False
 
         if self.rna_type == "SO:0000234":

--- a/rnacentral_pipeline/databases/data/entry.py
+++ b/rnacentral_pipeline/databases/data/entry.py
@@ -114,6 +114,9 @@ class Entry:
     interactions: ty.List[Interaction] = utils.possibly_empty(list)
     go_annotations: ty.List[GoTermAnnotation] = utils.possibly_empty(list)
 
+    ## Track and cache validity for speed when writing
+    _valid: ty.Optional[bool] = attr.ib(default=None, init=False)
+
     @property
     def database_name(self) -> str:
         """
@@ -213,6 +216,13 @@ class Entry:
         return str(md5(self.sequence.encode("utf-8")))
 
     def is_valid(self) -> bool:
+        if self._valid is not None:
+            return self._valid
+        res = self._compute_is_valid()
+        object.__setattr__(self, "_valid", res)
+        return res
+
+    def _compute_is_valid(self) -> bool:
         """
         Detect if this entry is valid. This means it is neither too short (< 10
         nt) not too long (> 1000000 nts) and has less than 10% N's.

--- a/rnacentral_pipeline/databases/data/entry.py
+++ b/rnacentral_pipeline/databases/data/entry.py
@@ -114,8 +114,9 @@ class Entry:
     interactions: ty.List[Interaction] = utils.possibly_empty(list)
     go_annotations: ty.List[GoTermAnnotation] = utils.possibly_empty(list)
 
-    ## Track and cache validity for speed when writing
-    _valid: ty.Optional[bool] = attr.ib(default=None, init=False)
+    ## Track and cache validity for speed when writing. eq/repr excluded so this
+    ## mutable cache stays out of the frozen value object's identity.
+    _valid: ty.Optional[bool] = attr.ib(default=None, init=False, eq=False, repr=False)
 
     @property
     def database_name(self) -> str:

--- a/rnacentral_pipeline/databases/data/references.py
+++ b/rnacentral_pipeline/databases/data/references.py
@@ -48,7 +48,7 @@ class UnknownPublicationType(Exception):
     pass
 
 
-@attr.s(frozen=True)
+@attr.s(frozen=True, slots=True)
 class Reference(object):
     """
     This stores the data for a reference that will be written to out to csv

--- a/rnacentral_pipeline/databases/data/references.py
+++ b/rnacentral_pipeline/databases/data/references.py
@@ -55,9 +55,9 @@ class Reference(object):
     files.
     """
 
-    authors: str = attr.ib(validator=is_a(str), converter=str)
-    location: str = attr.ib(validator=is_a(str), converter=str)
-    title: ty.Optional[str] = attr.ib(validator=optional(is_a(str)), converter=str)
+    authors: str = attr.ib(validator=is_a(str))
+    location: str = attr.ib(validator=is_a(str))
+    title: ty.Optional[str] = attr.ib(validator=optional(is_a(str)))
     pmid: ty.Optional[int] = attr.ib(validator=optional(is_a(int)))
     doi: ty.Optional[str] = attr.ib(validator=optional(is_a(str)))
     pmcid: ty.Optional[str] = attr.ib(validator=optional(is_a(str)), default=None)

--- a/rnacentral_pipeline/databases/data/utils.py
+++ b/rnacentral_pipeline/databases/data/utils.py
@@ -14,6 +14,7 @@ limitations under the License.
 """
 
 import re
+from functools import lru_cache
 
 import attr
 from attr.validators import instance_of as is_a
@@ -183,6 +184,7 @@ def matches_pattern(pattern):
     return fn
 
 
+@lru_cache(maxsize=None)
 def as_so_term(rna_type: str) -> str:
     if re.match(SO_PATTERN, rna_type):
         return rna_type

--- a/rnacentral_pipeline/databases/ena/context.py
+++ b/rnacentral_pipeline/databases/ena/context.py
@@ -14,20 +14,19 @@ limitations under the License.
 """
 
 import csv
+import typing as ty
 from collections import Counter
 from pathlib import Path
-import typing as ty
 
 import attr
-from attr.validators import optional
 from attr.validators import instance_of as is_a
-
+from attr.validators import optional
 from sqlitedict import SqliteDict
 
 from rnacentral_pipeline.databases.data import Entry
 from rnacentral_pipeline.databases.ena import dr
-from rnacentral_pipeline.databases.ena import ribovore as ribo
 from rnacentral_pipeline.databases.ena import mapping as tpa
+from rnacentral_pipeline.databases.ena import ribovore as ribo
 
 
 @attr.s()
@@ -35,6 +34,7 @@ class Context:
     ribovore: ty.Optional[ribo.Results] = attr.ib(validator=optional(is_a(dict)))
     tpa = attr.ib(validator=is_a(tpa.TpaMappings))
     dr = attr.ib(validator=is_a(SqliteDict))
+    dr_ids = attr.ib(validator=is_a(ty.Set))
     counts = attr.ib(validator=is_a(Counter), factory=Counter)
 
     def expand_tpa(self, entries: ty.Iterable[Entry]) -> ty.Iterable[Entry]:
@@ -68,6 +68,7 @@ class ContextBuilder:
     lengths_path = attr.ib(validator=optional(is_a(Path)), default=None)
     tpa_path = attr.ib(validator=optional(is_a(Path)), default=None)
     dr_path = attr.ib(validator=optional(is_a(Path)), default=None)
+    dr_ids = attr.ib(validator=optional(is_a(ty.Set)), default=None)
     cache_filename = attr.ib(validator=optional(is_a(Path)), default=None)
 
     def with_ribovore(self, ribovore_path: Path, lengths_path: Path):
@@ -92,9 +93,11 @@ class ContextBuilder:
             tpa_mapping.validate()
 
         dr_map = SqliteDict(filename=self.cache_filename)
+        dr_ids = set()
         if self.dr_path:
             with self.dr_path.open("r") as raw:
                 for (record_id, dbrefs) in dr.mappings(raw):
+                    dr_ids.add(record_id)
                     dr_map[record_id] = dbrefs
                 dr_map.commit()
 
@@ -106,4 +109,5 @@ class ContextBuilder:
             ribovore=ribovore,
             tpa=tpa_mapping,
             dr=dr_map,
+            dr_ids=dr_ids,
         )

--- a/rnacentral_pipeline/databases/ena/context.py
+++ b/rnacentral_pipeline/databases/ena/context.py
@@ -21,19 +21,21 @@ from pathlib import Path
 import attr
 from attr.validators import instance_of as is_a
 from attr.validators import optional
-from sqlitedict import SqliteDict
 
 from rnacentral_pipeline.databases.data import Entry
 from rnacentral_pipeline.databases.ena import dr
 from rnacentral_pipeline.databases.ena import mapping as tpa
 from rnacentral_pipeline.databases.ena import ribovore as ribo
+from rnacentral_pipeline.databases.ena.spill_dict import SpillDict
+
+DEFAULT_DR_THRESHOLD_BYTES = 1024 * 1024 * 1024  # 1 GiB of payload string data
 
 
 @attr.s()
 class Context:
     ribovore: ty.Optional[ribo.Results] = attr.ib(validator=optional(is_a(dict)))
     tpa = attr.ib(validator=is_a(tpa.TpaMappings))
-    dr = attr.ib(validator=is_a(SqliteDict))
+    dr = attr.ib(validator=is_a(SpillDict))
     dr_ids = attr.ib(validator=is_a(ty.Set))
     counts = attr.ib(validator=is_a(Counter), factory=Counter)
 
@@ -70,6 +72,9 @@ class ContextBuilder:
     dr_path = attr.ib(validator=optional(is_a(Path)), default=None)
     dr_ids = attr.ib(validator=optional(is_a(ty.Set)), default=None)
     cache_filename = attr.ib(validator=optional(is_a(Path)), default=None)
+    dr_threshold_bytes: int = attr.ib(
+        validator=is_a(int), default=DEFAULT_DR_THRESHOLD_BYTES
+    )
 
     def with_ribovore(self, ribovore_path: Path, lengths_path: Path):
         self.ribovore_path = ribovore_path
@@ -85,6 +90,10 @@ class ContextBuilder:
         self.cache_filename = cache_filename
         return self
 
+    def with_dr_threshold(self, threshold_bytes: int):
+        self.dr_threshold_bytes = threshold_bytes
+        return self
+
     def context(self) -> Context:
         tpa_mapping = tpa.TpaMappings()
         if self.tpa_path:
@@ -92,7 +101,10 @@ class ContextBuilder:
                 tpa_mapping = tpa.load(raw)
             tpa_mapping.validate()
 
-        dr_map = SqliteDict(filename=self.cache_filename)
+        dr_map = SpillDict(
+            threshold_bytes=self.dr_threshold_bytes,
+            spill_path=self.cache_filename,
+        )
         dr_ids = set()
         if self.dr_path:
             with self.dr_path.open("r") as raw:

--- a/rnacentral_pipeline/databases/ena/context.py
+++ b/rnacentral_pipeline/databases/ena/context.py
@@ -57,6 +57,16 @@ class Context:
     def add_parsed(self):
         self.counts["parsed"] += 1
 
+    def close(self):
+        self.dr.close()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+        return False
+
     def dump_counts(self, path: Path):
         with path.open("w") as out:
             writer = csv.DictWriter(out, fieldnames=self.counts.keys())

--- a/rnacentral_pipeline/databases/ena/helpers.py
+++ b/rnacentral_pipeline/databases/ena/helpers.py
@@ -360,7 +360,10 @@ def as_entry(ctx, record, feature) -> Entry:
     if gene:
         gene = gene[0:200]
 
-    record_refs = ctx.dr[record.id]
+    if record.id in ctx.dr_ids:
+        record_refs = ctx.dr[record.id]
+    else:
+        record_refs = []
     return Entry(
         primary_id=primary_id(feature),
         accession=accession(record),

--- a/rnacentral_pipeline/databases/ena/helpers.py
+++ b/rnacentral_pipeline/databases/ena/helpers.py
@@ -288,19 +288,28 @@ def description(record) -> str:
     return re.sub(r"^TPA:\s*", "", raw)
 
 
+_XREF_LINE = re.compile(
+    r"^\s*(" + "|".join(KNOWN_DBS) + r")\s*;\s*(.+?)\s*\.?$",
+    re.IGNORECASE,
+)
+_XREF_SPLIT = re.compile(r"\s*;\s*")
+
+
 def comment_xrefs(comments):
     xrefs = coll.defaultdict(list)
     for line in comments:
-        match = re.match(r"^\s*(.+?)\s*;\s*(.+?)\s*\.?$", line)
-        if match:
-            db_name = match.group(1).lower()
-            if db_name not in KNOWN_DBS:
-                continue
-            rest = match.group(2)
-            if ";" in rest:
-                xrefs[db_name].extend(re.split(r"\s*;\s*", rest))
-            else:
-                xrefs[db_name].append(rest)
+        if ";" not in line:
+            continue
+        match = _XREF_LINE.match(line)
+        if not match:
+            continue
+
+        db_name = match.group(1).lower()
+        rest = match.group(2)
+        if ";" in rest:
+            xrefs[db_name].extend(_XREF_SPLIT.split(rest))
+        else:
+            xrefs[db_name].append(rest)
     return xrefs
 
 

--- a/rnacentral_pipeline/databases/ena/parser.py
+++ b/rnacentral_pipeline/databases/ena/parser.py
@@ -13,17 +13,17 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import typing as ty
 import logging
+import typing as ty
 from pathlib import Path
 
 from Bio import SeqIO
 
 import rnacentral_pipeline.databases.helpers.embl as embl
 from rnacentral_pipeline.databases.data import Entry
-
-from rnacentral_pipeline.databases.ena import context, dr, helpers, ribovore
+from rnacentral_pipeline.databases.ena import context, dr, helpers
 from rnacentral_pipeline.databases.ena import mapping as tpa
+from rnacentral_pipeline.databases.ena import ribovore
 
 LOGGER = logging.getLogger(__name__)
 
@@ -65,7 +65,7 @@ def parse(ctx: context.Context, path: Path) -> ty.Iterable[Entry]:
             ctx.add_skipped_pseudogene()
             continue
 
-        if record.id not in ctx.dr:
+        if record.id not in ctx.dr_ids:
             raise InvalidEnaFile("Somehow parsed DR refs are for wrong record")
 
         entry = helpers.as_entry(ctx, record, feature)

--- a/rnacentral_pipeline/databases/ena/spill_dict.py
+++ b/rnacentral_pipeline/databases/ena/spill_dict.py
@@ -1,0 +1,108 @@
+# -*- coding: utf-8 -*-
+
+"""
+Copyright [2009-2026] EMBL-European Bioinformatics Institute
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import logging
+import tempfile
+import typing as ty
+from pathlib import Path
+
+from sqlitedict import SqliteDict
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _estimate_size(key: str, value: ty.Any) -> int:
+    """
+    Cheap proxy for "bytes of payload" — sums string lengths of the key and any
+    string attributes reachable on the value. Not RAM-accurate (Python object
+    overhead is significant), but monotonic and tunable: set the threshold below
+    your real memory budget and tune from there.
+    """
+    total = len(key)
+    if isinstance(value, list):
+        for item in value:
+            slots = getattr(item, "__dict__", None)
+            if slots is None:
+                total += len(str(item))
+                continue
+            for v in slots.values():
+                if isinstance(v, str):
+                    total += len(v)
+    return total
+
+
+class SpillDict:
+    """
+    Mapping that starts in memory and spills to a SqliteDict on disk once the
+    estimated payload size crosses a threshold. After spill, all reads and
+    writes go to disk; the in-memory dict is migrated and cleared.
+
+    Only implements the slice of the Mapping protocol that ena.Context uses.
+    """
+
+    def __init__(self, threshold_bytes: int, spill_path: ty.Optional[Path] = None):
+        self._mem: ty.Dict[str, ty.Any] = {}
+        self._disk: ty.Optional[SqliteDict] = None
+        self._size = 0
+        self._threshold = threshold_bytes
+        self._spill_path = spill_path
+
+    def __setitem__(self, key, value):
+        if self._disk is not None:
+            self._disk[key] = value
+            return
+        self._mem[key] = value
+        self._size += _estimate_size(key, value)
+        if self._size >= self._threshold:
+            self._spill()
+
+    def __getitem__(self, key):
+        if self._disk is not None:
+            return self._disk[key]
+        return self._mem[key]
+
+    def __contains__(self, key):
+        if self._disk is not None:
+            return key in self._disk
+        return key in self._mem
+
+    def __len__(self):
+        if self._disk is not None:
+            return len(self._disk)
+        return len(self._mem)
+
+    def commit(self):
+        if self._disk is not None:
+            self._disk.commit()
+
+    @property
+    def spilled(self) -> bool:
+        return self._disk is not None
+
+    def _spill(self):
+        if self._spill_path is None:
+            self._spill_path = Path(tempfile.mkstemp(prefix="ena-dr-")[1])
+        LOGGER.info(
+            "SpillDict crossing threshold (%d entries, ~%d payload bytes); "
+            "spilling to %s",
+            len(self._mem),
+            self._size,
+            self._spill_path,
+        )
+        self._disk = SqliteDict(filename=str(self._spill_path))
+        for k, v in self._mem.items():
+            self._disk[k] = v
+        self._disk.commit()
+        self._mem.clear()

--- a/rnacentral_pipeline/databases/ena/spill_dict.py
+++ b/rnacentral_pipeline/databases/ena/spill_dict.py
@@ -17,11 +17,27 @@ import logging
 import os
 import tempfile
 import typing as ty
+import weakref
 from pathlib import Path
 
 from sqlitedict import SqliteDict
 
 LOGGER = logging.getLogger(__name__)
+
+
+def _iter_string_attrs(item: ty.Any) -> ty.Iterator[str]:
+    cls_slots = getattr(type(item), "__slots__", None)
+    if cls_slots is not None:
+        for name in cls_slots:
+            v = getattr(item, name, None)
+            if isinstance(v, str):
+                yield v
+        return
+    instance_dict = getattr(item, "__dict__", None)
+    if instance_dict is not None:
+        for v in instance_dict.values():
+            if isinstance(v, str):
+                yield v
 
 
 def _estimate_size(key: str, value: ty.Any) -> int:
@@ -34,13 +50,8 @@ def _estimate_size(key: str, value: ty.Any) -> int:
     total = len(key)
     if isinstance(value, list):
         for item in value:
-            slots = getattr(item, "__dict__", None)
-            if slots is None:
-                total += len(str(item))
-                continue
-            for v in slots.values():
-                if isinstance(v, str):
-                    total += len(v)
+            for s in _iter_string_attrs(item):
+                total += len(s)
     return total
 
 
@@ -59,6 +70,8 @@ class SpillDict:
         self._size = 0
         self._threshold = threshold_bytes
         self._spill_path = spill_path
+        self._owns_spill_file = spill_path is None
+        self._finalizer: ty.Optional[weakref.finalize] = None
 
     def __setitem__(self, key, value):
         if self._disk is not None:
@@ -92,6 +105,32 @@ class SpillDict:
     def spilled(self) -> bool:
         return self._disk is not None
 
+    def close(self):
+        if self._finalizer is not None and self._finalizer.alive:
+            self._finalizer()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+        return False
+
+    @staticmethod
+    def _cleanup(disk: ty.Optional[SqliteDict], path: ty.Optional[Path], owns: bool):
+        if disk is not None:
+            try:
+                disk.close()
+            except Exception:
+                LOGGER.exception("Error closing SqliteDict at %s", path)
+        if owns and path is not None:
+            try:
+                os.unlink(path)
+            except FileNotFoundError:
+                pass
+            except OSError:
+                LOGGER.exception("Error removing SpillDict temp file %s", path)
+
     def _spill(self):
         if self._spill_path is None:
             fd, name = tempfile.mkstemp(prefix="ena-dr-")
@@ -109,3 +148,6 @@ class SpillDict:
             self._disk[k] = v
         self._disk.commit()
         self._mem.clear()
+        self._finalizer = weakref.finalize(
+            self, self._cleanup, self._disk, self._spill_path, self._owns_spill_file
+        )

--- a/rnacentral_pipeline/databases/ena/spill_dict.py
+++ b/rnacentral_pipeline/databases/ena/spill_dict.py
@@ -14,6 +14,7 @@ limitations under the License.
 """
 
 import logging
+import os
 import tempfile
 import typing as ty
 from pathlib import Path
@@ -93,7 +94,9 @@ class SpillDict:
 
     def _spill(self):
         if self._spill_path is None:
-            self._spill_path = Path(tempfile.mkstemp(prefix="ena-dr-")[1])
+            fd, name = tempfile.mkstemp(prefix="ena-dr-")
+            os.close(fd)
+            self._spill_path = Path(name)
         LOGGER.info(
             "SpillDict crossing threshold (%d entries, ~%d payload bytes); "
             "spilling to %s",

--- a/rnacentral_pipeline/databases/helpers/hashes.py
+++ b/rnacentral_pipeline/databases/helpers/hashes.py
@@ -15,7 +15,10 @@ limitations under the License.
 
 import hashlib
 
-import crcmod
+try:
+    import crcmod
+except ImportError:
+    crcmod = None
 
 
 def md5(data):
@@ -76,10 +79,17 @@ def crc64_python(input_string):
     return "%08X%08X" % (crch, crcl)
 
 
-_crc64_swiss = crcmod.mkCrcFun(0x1000000000000001B, initCrc=0, rev=True, xorOut=0)
+if crcmod is not None:
+    _crc64_swiss = crcmod.mkCrcFun(0x1000000000000001B, initCrc=0, rev=True, xorOut=0)
+else:
+    _crc64_swiss = None
 
 
 def crc64(input_string):
+    if _crc64_swiss is None:
+        if isinstance(input_string, bytes):
+            input_string = input_string.decode("ascii")
+        return crc64_python(input_string)
     if isinstance(input_string, str):
         input_string = input_string.encode("ascii")
     return "%016X" % _crc64_swiss(input_string)

--- a/rnacentral_pipeline/databases/helpers/hashes.py
+++ b/rnacentral_pipeline/databases/helpers/hashes.py
@@ -15,6 +15,8 @@ limitations under the License.
 
 import hashlib
 
+import crcmod
+
 
 def md5(data):
     """
@@ -48,12 +50,17 @@ def _build_crc64_tables():
 _CRC64_TABLE_H, _CRC64_TABLE_L = _build_crc64_tables()
 
 
-def crc64(input_string):
+def crc64_python(input_string):
     """
     Python re-implementation of SWISS::CRC64
     Adapted from:
     http://code.activestate.com/recipes/259177-crc64-calculate-the-cyclic-redundancy-check/
     The generator polynomial is x64 + x4 + x3 + x + 1.
+
+    This is kept as a fallback incase crcmod is not available. It is quite a bit slower though.
+
+    Implementation below tested against 49,991 samples from ENA and gave identical results
+
     """
     crcl = 0
     crch = 0
@@ -67,3 +74,12 @@ def crc64(input_string):
         crch = temp1h ^ _CRC64_TABLE_H[tableindex]
         crcl = temp1l ^ _CRC64_TABLE_L[tableindex]
     return "%08X%08X" % (crch, crcl)
+
+
+_crc64_swiss = crcmod.mkCrcFun(0x1000000000000001B, initCrc=0, rev=True, xorOut=0)
+
+
+def crc64(input_string):
+    if isinstance(input_string, str):
+        input_string = input_string.encode("ascii")
+    return "%016X" % _crc64_swiss(input_string)

--- a/rnacentral_pipeline/databases/helpers/hashes.py
+++ b/rnacentral_pipeline/databases/helpers/hashes.py
@@ -23,35 +23,40 @@ def md5(data):
     return hashlib.md5(data).hexdigest()
 
 
+_POLY64REVh = 0xD8000000
+
+
+def _build_crc64_tables():
+    table_h = [0] * 256
+    table_l = [0] * 256
+    for i in range(256):
+        partl = i
+        parth = 0
+        for _ in range(8):
+            rflag = partl & 1
+            partl >>= 1
+            if parth & 1:
+                partl |= 1 << 31
+            parth >>= 1
+            if rflag:
+                parth ^= _POLY64REVh
+        table_h[i] = parth
+        table_l[i] = partl
+    return table_h, table_l
+
+
+_CRC64_TABLE_H, _CRC64_TABLE_L = _build_crc64_tables()
+
+
 def crc64(input_string):
     """
     Python re-implementation of SWISS::CRC64
     Adapted from:
     http://code.activestate.com/recipes/259177-crc64-calculate-the-cyclic-redundancy-check/
+    The generator polynomial is x64 + x4 + x3 + x + 1.
     """
-
-    POLY64REVh = 0xD8000000
-    CRCTableh = [0] * 256
-    CRCTablel = [0] * 256
-    isInitialized = False
     crcl = 0
     crch = 0
-    if isInitialized is not True:
-        isInitialized = True
-        for i in range(256):
-            partl = i
-            parth = 0
-            for _ in range(8):
-                rflag = partl & 1
-                partl >>= 1
-                if parth & 1:
-                    partl |= 1 << 31
-                parth >>= 1
-                if rflag:
-                    parth ^= POLY64REVh
-            CRCTableh[i] = parth
-            CRCTablel[i] = partl
-
     for item in input_string:
         shr = 0
         shr = (crch & 0xFF) << 24
@@ -59,6 +64,6 @@ def crc64(input_string):
         temp1l = (crcl >> 8) | shr
         tableindex = (crcl ^ ord(item)) & 0xFF
 
-        crch = temp1h ^ CRCTableh[tableindex]
-        crcl = temp1l ^ CRCTablel[tableindex]
+        crch = temp1h ^ _CRC64_TABLE_H[tableindex]
+        crcl = temp1l ^ _CRC64_TABLE_L[tableindex]
     return "%08X%08X" % (crch, crcl)

--- a/uv.lock
+++ b/uv.lock
@@ -2,7 +2,8 @@ version = 1
 revision = 3
 requires-python = ">=3.11"
 resolution-markers = [
-    "python_full_version >= '3.13'",
+    "python_full_version >= '3.15'",
+    "python_full_version >= '3.13' and python_full_version < '3.15'",
     "python_full_version == '3.12.*'",
     "python_full_version < '3.12'",
 ]
@@ -160,6 +161,46 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/4f/34/bc0b3577a818b4b70c6e318d23fe3c81fc3bb25f978ca8a3965cd8ee3af9/argh-0.31.3.tar.gz", hash = "sha256:f30023d8be14ca5ee6b1b3eeab829151d7bbda464ae07dc4dd5347919c5892f9", size = 57570, upload-time = "2024-07-13T17:54:59.729Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/52/fcd83710b6f8786df80e5d335882d1b24d1f610f397703e94a6ffb0d6f66/argh-0.31.3-py3-none-any.whl", hash = "sha256:2edac856ff50126f6e47d884751328c9f466bacbbb6cbfdac322053d94705494", size = 44844, upload-time = "2024-07-13T17:54:57.706Z" },
+]
+
+[[package]]
+name = "ast-serialize"
+version = "0.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/81/9d/09e27731bd5864a9ce04e3244074e674bb8936bf62b45e0357248717adac/ast_serialize-0.5.0.tar.gz", hash = "sha256:5880091bfe6f4f986f22866375c2e884843e7a0b6343ae41aeea659613d879b6", size = 61157, upload-time = "2026-05-17T17:48:29.429Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/9a/13dde51ba9e15f8b97957ab7cb0120d0e381524d651c6bd630b9c359227f/ast_serialize-0.5.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:8f5c14f169eb0972c0c21bada5358b23d6047c76583b005234f865b11f1fa00a", size = 1183520, upload-time = "2026-05-17T17:47:30.831Z" },
+    { url = "https://files.pythonhosted.org/packages/37/de/5a7f0a9fe68944f536632a5af84676739c7d2582be42deb082634bf3a754/ast_serialize-0.5.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7d1a2de9de5be04652f0ed60738356ef94f66db37924a9499fffe98dc491aa0b", size = 1175779, upload-time = "2026-05-17T17:47:32.551Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/81/0bb853e76e4f6e9a1855d569003c59e19ffac45f7079d91505d1bb212f92/ast_serialize-0.5.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:be5173fb66f9b49026d9d5a2ff0fc7c7009077107c0eb285b2d60fdf1fe10bd1", size = 1233750, upload-time = "2026-05-17T17:47:34.731Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/d3/4cf705beeccc08754d0bbda99aefff26110e209b9a07ac8a6b60eec48531/ast_serialize-0.5.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f8015cd071ac1339924ee2b8098c93e00e155f30a16f40ec9816fcf84f4753f6", size = 1235942, upload-time = "2026-05-17T17:47:36.287Z" },
+    { url = "https://files.pythonhosted.org/packages/26/c8/ee097e437ea27dd2b8b227865c875492b585650a5802a22d82b304c8201b/ast_serialize-0.5.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5499e8797edff2a9186aa313ed382c6b422e798e9332d9953badcee6e69a88f2", size = 1442517, upload-time = "2026-05-17T17:47:38.17Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/bd/68063442838f1ba68ec72b5436430bc75b3bb17a1a3c3063f09b0c05ae2b/ast_serialize-0.5.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6848f2a093fb5548751a9a09bff8fcd229e2bbeb0e3331f391b6ae6d26cd9903", size = 1254081, upload-time = "2026-05-17T17:47:39.826Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e2/1e520793bc6a4e4524a6ab022391e827825eaa0c3811828bfdc6852eca26/ast_serialize-0.5.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:832d4c998e0b091fd60a6d6bceee535483c4d490de9ba85003af835225719261", size = 1259910, upload-time = "2026-05-17T17:47:41.369Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/e1/49b60f467979979cfe6913b43948ff25bca971ad0591d181812f163a988e/ast_serialize-0.5.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:16db7c62ec0b8efe1d7afd283a388d8f74f2605d56032e5a37747d2de8dba027", size = 1250678, upload-time = "2026-05-17T17:47:43.702Z" },
+    { url = "https://files.pythonhosted.org/packages/74/ba/66ab9555de6275677566f6574e5ef6c29cb185ea866f643bc06f8280a8ee/ast_serialize-0.5.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:baf5eb061eb5bccade4128ad42da33787d72f6013809cd1b590376ece8b3c937", size = 1301603, upload-time = "2026-05-17T17:47:46.256Z" },
+    { url = "https://files.pythonhosted.org/packages/66/42/6aca9b9abc710014b2be9059689e5dd1679339e78f567ffb4d255a9e2050/ast_serialize-0.5.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:104e4a35bd7c124173c41760ef9aaea17ddb3f86c65cb643671d59afbe3ee94c", size = 1410332, upload-time = "2026-05-17T17:47:47.899Z" },
+    { url = "https://files.pythonhosted.org/packages/47/68/2f76594432a22581ecf878b5e75a9b8601c24b2241cf0bbeb1e21fcf370c/ast_serialize-0.5.0-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:36be371028fc1675acb38a331bde160dbab7ff907fdf00b67eb6911aa106951b", size = 1509979, upload-time = "2026-05-17T17:47:50.942Z" },
+    { url = "https://files.pythonhosted.org/packages/40/ac/a93c9b58292653f6c595752f677a08e608f903b710594909e9231a389b3b/ast_serialize-0.5.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:061ee58bdb52341c8201a6df41182a977736bae3b7ded87ca7176ca25a8a47ab", size = 1505002, upload-time = "2026-05-17T17:47:54.093Z" },
+    { url = "https://files.pythonhosted.org/packages/14/2e/b278f68c497ee2f1d1576cbbef8db5281cd4a5f2db040537592ac9c8862e/ast_serialize-0.5.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:b15219e9cdc9f53f6f4cb51c009203507228226148c05c5e8fe451c28b435eb3", size = 1456231, upload-time = "2026-05-17T17:47:56.311Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/43/419be1c566a4c504cd8fd60ce2f84e790f295495c0f327cfaeadf3d51012/ast_serialize-0.5.0-cp314-cp314t-win32.whl", hash = "sha256:842d1c004bb466c7df036f95fabef789570541922b10976b12f5592a69cf0b38", size = 1058668, upload-time = "2026-05-17T17:47:58.305Z" },
+    { url = "https://files.pythonhosted.org/packages/03/6f/c9d4d549295ed05111aeb8853232d1afd9d0a179fddb01eeffbb3a4a6842/ast_serialize-0.5.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b0c06d760909b095cc466356dfccd05a1c7233a6ca191c020dca2c6a6f16c24c", size = 1101075, upload-time = "2026-05-17T17:48:00.35Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/8e/d00c5ab30c58222e07d62956fca86c59d91b9ad32997e633c38b526623a3/ast_serialize-0.5.0-cp314-cp314t-win_arm64.whl", hash = "sha256:787baedb0262cc49e8ce37cc15c00ae818e46a165a3b36f5e21ed174998104cb", size = 1075347, upload-time = "2026-05-17T17:48:01.753Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/9e/dc2530acb3a60dc6e46d65abf27d1d9f86721694757906a148d90a6860de/ast_serialize-0.5.0-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:0668aa9459cfa8c9c49ddd2163ebcf43088ba045ef7492af6fe22e0098303101", size = 1191380, upload-time = "2026-05-17T17:48:03.738Z" },
+    { url = "https://files.pythonhosted.org/packages/26/0a/bd3d18a582f273d6c843d16bb9e22e9e16365ff7991e92f18f798e9f1224/ast_serialize-0.5.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:bf683d6363edf2b39eed6b6d4fe22d34b6203867a67e27134d9e2a2680c4bc4a", size = 1183879, upload-time = "2026-05-17T17:48:05.463Z" },
+    { url = "https://files.pythonhosted.org/packages/40/ae/1f919100f8620887af58fcc381c61a1f218cdf89c6e155f87b213e61010a/ast_serialize-0.5.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9cc22cf0c9be65e71cf88fda130af60d61eb4a79370ad4cfe7900d48a4aa2211", size = 1244529, upload-time = "2026-05-17T17:48:07.008Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/ca/6376559dcce707cdbc1d0d9a13c8d3baaaa501e949ce0ebdc4230cd881aa/ast_serialize-0.5.0-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f66173891548c9f2726bf27957b41cabce12fa679dc6da505ddbde4d4b3b31cf", size = 1240560, upload-time = "2026-05-17T17:48:08.46Z" },
+    { url = "https://files.pythonhosted.org/packages/35/b2/a620e206b5aeb7efbf2710336df57d457cffbb3991076bbcc1147ef9abd4/ast_serialize-0.5.0-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e42d729ef2be96a14efbad355093284739e3670ece3e534f82cc8832790911d9", size = 1451172, upload-time = "2026-05-17T17:48:09.922Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/e0/4ad5c04c24a40481b2935ce9a0ccdb6023dc8b667167d06ae530cc3512f2/ast_serialize-0.5.0-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b725026bafa801dbd7310eb13a75f0a2e370e7e51b2cb225f9d21fcfadf919ee", size = 1265072, upload-time = "2026-05-17T17:48:11.469Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/71/4d1d479aa56d0101c40e17720c3d6ac2af7269ea0487a80b18e7bfd1a5b7/ast_serialize-0.5.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b54f60c1d78767a53b67eaa663f0dfac3afe606aa07f1301572f588b73d64809", size = 1270488, upload-time = "2026-05-17T17:48:13.575Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/4f/0de1bbe06f6edef9fde4ed12ca8e7b3ec7e6e2bd4e672c5af487f7957665/ast_serialize-0.5.0-cp39-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:27d51654fc240a1e87e742d353d98eb45b75f62f129086b3596ab53df2ac2a43", size = 1260702, upload-time = "2026-05-17T17:48:15.141Z" },
+    { url = "https://files.pythonhosted.org/packages/75/61/e00872439cfdddcc3c1b6cdaa6e5d904ba8e26a18807c67c4e14409d0ca8/ast_serialize-0.5.0-cp39-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2782c36237c46dd1674542f2109740ea5ea485a169bf1431939ada0434e17934", size = 1311182, upload-time = "2026-05-17T17:48:16.779Z" },
+    { url = "https://files.pythonhosted.org/packages/76/8e/699a5b955f7926956c95e9e1d74132acad73c2fe7a426f94da89123c20aa/ast_serialize-0.5.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1943db345233cc7194a470f13afa9c59772c0b123dea0c9414c4d4ca54369759", size = 1421410, upload-time = "2026-05-17T17:48:18.527Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/ae/d5b7626874478997adc7a29ab28accf21e596fb590c944290401dfd0b29e/ast_serialize-0.5.0-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:df1c00022cbbcb064bfaa505aa9c9295362443ce5dacb459d1331d3da353f887", size = 1516587, upload-time = "2026-05-17T17:48:20.133Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/ce/b59e02a82d9c4244d64cde502e0b00e83e38816abe19155ceb5437402c7f/ast_serialize-0.5.0-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:cae65289fc456fde04af979a2be09302ef5d8ab92ef23e596d6746dc267ada27", size = 1515171, upload-time = "2026-05-17T17:48:21.921Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/38/d8d90042747d05aa08d4efcf1c99035a5f670a6bf4c214d31644392afbca/ast_serialize-0.5.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:239a4c354e8d676e9d94631d1d4a64edc6b266f86ff3a5a80aedd344f342c01d", size = 1464668, upload-time = "2026-05-17T17:48:23.544Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/51/5b840c4df7334104cecffa28f23904fe81ca89ca223d2450e288de39fd3c/ast_serialize-0.5.0-cp39-abi3-win32.whl", hash = "sha256:143a4ef63285a075871908fda3672dc21864b83a8ec3ee12304aa3e4c5387b9a", size = 1068311, upload-time = "2026-05-17T17:48:25.027Z" },
+    { url = "https://files.pythonhosted.org/packages/41/11/ca5672c7d491825bc4cd6702dea106a6b60d928707712ec257c7833ae476/ast_serialize-0.5.0-cp39-abi3-win_amd64.whl", hash = "sha256:cf25572c526add400f26a4750dc6ce0c3bb93fc1f75e7ae0cad4ce4f2cd5c590", size = 1108931, upload-time = "2026-05-17T17:48:26.591Z" },
+    { url = "https://files.pythonhosted.org/packages/45/19/cc8bd127d28a43da249aa955cfd164cf8fd534e79e42cea96c4854d72fd0/ast_serialize-0.5.0-cp39-abi3-win_arm64.whl", hash = "sha256:92a31c9c20d25a076edaeec76b128a3535d74a24f340b9a8a7e96c9b86dc9642", size = 1081181, upload-time = "2026-05-17T17:48:28.122Z" },
 ]
 
 [[package]]
@@ -396,6 +437,12 @@ sdist = { url = "https://files.pythonhosted.org/packages/cc/c7/eed8f27100517e8c0
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/06/3d6badcf13db419e25b07041d9c7b4a2c331d3f4e7134445ec5df57714cd/coloredlogs-15.0.1-py2.py3-none-any.whl", hash = "sha256:612ee75c546f53e92e70049c9dbfcc18c935a2b9a53b66085ce9ef6a6e5c0934", size = 46018, upload-time = "2021-06-11T10:22:42.561Z" },
 ]
+
+[[package]]
+name = "crcmod"
+version = "1.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6b/b0/e595ce2a2527e169c3bcd6c33d2473c1918e0b7f6826a043ca1245dd4e5b/crcmod-1.7.tar.gz", hash = "sha256:dc7051a0db5f2bd48665a990d3ec1cc305a466a77358ca4492826f41f283601e", size = 89670, upload-time = "2010-06-27T14:35:29.538Z" }
 
 [[package]]
 name = "cython"
@@ -937,6 +984,79 @@ wheels = [
 ]
 
 [[package]]
+name = "librt"
+version = "0.11.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/40/08/9e7f6b5d2b5bed6ad055cdd5925f192bb403a51280f86b56554d9d0699a2/librt-0.11.0.tar.gz", hash = "sha256:075dc3ef4458a278e0195cbf6ac9d38808d9b906c5a6c7f7f79c3888276a3fb1", size = 200139, upload-time = "2026-05-10T18:17:25.138Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/87/2bf31fe17587b29e3f93ec31421e2b1e1c3e349b8bf6c7c313dbad1d5340/librt-0.11.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:93d95bd45b7d58343d8b90d904450a545144eec19a002511163426f8ab1fae29", size = 141092, upload-time = "2026-05-10T18:15:34.795Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/08/5c5bf772920b7ebac6e32bc91a643e0ab3870199c0b542356d3baa83970a/librt-0.11.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4ee278c769a713638cdacd4c0436d72156e75df3ebc0166ab2b9dc43acc386c9", size = 142035, upload-time = "2026-05-10T18:15:36.242Z" },
+    { url = "https://files.pythonhosted.org/packages/06/20/662a03d254e5b000d838e8b345d83303ddb768c080fd488e40634c0fa66b/librt-0.11.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f230cb1cbc9faaa616f9a678f530ebcf186e414b6bcbd88b960e4ba1b92428d5", size = 475022, upload-time = "2026-05-10T18:15:37.56Z" },
+    { url = "https://files.pythonhosted.org/packages/de/f3/aa81523e45184c6ec23dc7f63263362ec55f80a09d424c012359ecbe7e35/librt-0.11.0-cp311-cp311-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:5d63c855d86938d9de93e265c9bd8c705b51ec494de5738340ee93767a686e4b", size = 467273, upload-time = "2026-05-10T18:15:39.182Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/6f/59c74b560ca8853834d5501d589c8a2519f4184f273a085ffd0f37a1cc47/librt-0.11.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:993f028be9e96a08d31df3479ac80d99be374d17f3b78e4796b3fd3c913d4e89", size = 497083, upload-time = "2026-05-10T18:15:40.634Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/7b/5aa4d2c9600a719401160bf7055417df0b2a47439b9d88286ce45e56b65f/librt-0.11.0-cp311-cp311-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:258d73a0aa66a055e65b2e4d1b8cdb23b9d132c5bb915d9547d804fcaed116cc", size = 489139, upload-time = "2026-05-10T18:15:41.934Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/31/9143803d7da6856a69153785768c4936864430eec0fd9461c3ea527d9922/librt-0.11.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:0827efe7854718f04aaddf6496e96960a956e676fe1d0f04eb41511fd8ad06d5", size = 508442, upload-time = "2026-05-10T18:15:43.206Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/5a/bce08184488426bda4ccc2c4964ac048c8f68ae89bd7120082eef4233cfd/librt-0.11.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:7753e57d6e12d019c0d8786f1c09c709f4c3fcc57c3887b24e36e6c06ec938b7", size = 514230, upload-time = "2026-05-10T18:15:44.761Z" },
+    { url = "https://files.pythonhosted.org/packages/89/8c/bb5e213d254b7505a0e658da199d8ab719086632ce09eef311ab27976523/librt-0.11.0-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:11bd19822431cc21af9f27374e7ae2e58103c7d98bda823536a6c47f6bb2bb3d", size = 494231, upload-time = "2026-05-10T18:15:46.308Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/fb/541cdad5b1ab1300398c74c4c9a497b88e5074c21b1244c8f49731d3a284/librt-0.11.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:22bdf239b219d3993761a148ffa134b19e52e9989c84f845d5d7b71d70a17412", size = 537585, upload-time = "2026-05-10T18:15:47.629Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/f2/464bb69295c320cb06bddb4f14a4ec67934ee14b2bffb12b19fb7ab287ba/librt-0.11.0-cp311-cp311-win32.whl", hash = "sha256:46c60b61e308eb535fbd6fa622b1ee1bb2815691c1ad9c98bf7b84952ec3bc8d", size = 100509, upload-time = "2026-05-10T18:15:49.157Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/e7/a17ee1788f9e4fbf548c19f4afa07c92089b9e24fef6cb2410863781ef4c/librt-0.11.0-cp311-cp311-win_amd64.whl", hash = "sha256:902e546ff044f579ff1c953ff5fce97b636fe9e3943996b2177710c6ef076f73", size = 118628, upload-time = "2026-05-10T18:15:50.345Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/c7/6c766214f9f9903bcfcfbef97d807af8d8f5aa3502d247858ab17582d212/librt-0.11.0-cp311-cp311-win_arm64.whl", hash = "sha256:65ac3bc20f78aa0ee5ae84baa68917f89fef4af63e941084dd019a0d0e749f0c", size = 103122, upload-time = "2026-05-10T18:15:52.068Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/d0/07c77e067f0838949b43bd89232c29d72efebb9d2801a9750184eb706b71/librt-0.11.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b87504f1690a23b9a2cca841191a04f83895d4fc2dd04df91d82b1a04ca2ad46", size = 144147, upload-time = "2026-05-10T18:15:53.227Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/24/8493538fa4f62f982686398a5b8f68008138a75086abdea19ade64bf4255/librt-0.11.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40071fc5fe0ce8daa6de616702314a01e1250711682b0523d6ab8d4525910cb3", size = 143614, upload-time = "2026-05-10T18:15:54.657Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/1e/f8bad050810d9171f34a1648ed910e56814c2ba61639f2bd53c6377ae24b/librt-0.11.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:137e79445c896a0ea7b265f52d23954e05b64222ee1af69e2cb34219067cbb67", size = 485538, upload-time = "2026-05-10T18:15:56.117Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/fe/3594ebfbaf03084ba4b120c9ba5c3183fd938a48725e9bbe6ff0a5159ad8/librt-0.11.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:cca6644054e78746d8d4ef238681f9c34ff8b584fe6b988ecebb8db3b15e622a", size = 479623, upload-time = "2026-05-10T18:15:57.544Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/da/5d1876984b3746c85dbd219dbfcb73c85f54ee263fd32e5b2a632ec14571/librt-0.11.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d5b0eea49f5562861ee8d757a32ef7d559c1d35be2aaaa1ec28941d74c9ffc8a", size = 513082, upload-time = "2026-05-10T18:15:58.805Z" },
+    { url = "https://files.pythonhosted.org/packages/19/6e/55bdf5d5ca00c3e18430690bf2c953d8d3ffd3c337418173d33dec985dc9/librt-0.11.0-cp312-cp312-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0d1029d7e1ae1a7e647ed6fb5df8c4ce2dffefb7a9f5fd1376a4554d96dac09f", size = 508105, upload-time = "2026-05-10T18:16:00.2Z" },
+    { url = "https://files.pythonhosted.org/packages/07/10/f1f23a7c595ee90ece4d35c851e5d104b1311a887ed1b4ac4c35bbd13da8/librt-0.11.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:bc3ce6b33c5828d9e80592011a5c584cb2ce86edbc4088405f70da47dc1d1b3b", size = 522268, upload-time = "2026-05-10T18:16:01.708Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/02/5720f5697a7f54b78b3aefbe20df3a48cedcff1276618c4aa481177942ed/librt-0.11.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:936c5995f3514a42111f20099397d8177c79b4d7e70961e396c6f5a0a3566766", size = 527348, upload-time = "2026-05-10T18:16:03.496Z" },
+    { url = "https://files.pythonhosted.org/packages/50/db/b4a47c6f91db4ff76348a0b3dd0cc65e090a078b765a810a62ff9434c3d3/librt-0.11.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:9bc0ca6ad9381cbe8e4aa6e5726e4c80c78115a6e9723c599ed1d73e092bc49d", size = 516294, upload-time = "2026-05-10T18:16:05.173Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/58/9384b2f4eb1ed1d273d40948a7c5c4b2360213b402ef3be4641c06299f9c/librt-0.11.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:070aa8c26c0a74774317a72df8851facc7f0f012a5b406557ac56992d92e1ec8", size = 553608, upload-time = "2026-05-10T18:16:06.839Z" },
+    { url = "https://files.pythonhosted.org/packages/21/7b/5aa8848a7c6a9278c79375146da1812e695754ceec5f005e6043461a7315/librt-0.11.0-cp312-cp312-win32.whl", hash = "sha256:6bf14feb84b05ae945277395451998c89c54d0def4070eb5c08de544930b245a", size = 101879, upload-time = "2026-05-10T18:16:08.103Z" },
+    { url = "https://files.pythonhosted.org/packages/37/33/8a745436944947575b584231750a41417de1a38cf6a2e9251d1065651c09/librt-0.11.0-cp312-cp312-win_amd64.whl", hash = "sha256:75672f0bc524ede266287d532d7923dbce94c7514ad07627bac3d0c6d92cc4d9", size = 119831, upload-time = "2026-05-10T18:16:09.174Z" },
+    { url = "https://files.pythonhosted.org/packages/59/67/a6739ac96e28b7855808bdb0370e250606104a859750d209e5a0716fe7ab/librt-0.11.0-cp312-cp312-win_arm64.whl", hash = "sha256:2f10cf143e4a9bb0f4f5af568a00df94a2d69ef41c2579584454bb0fe5cc642c", size = 103470, upload-time = "2026-05-10T18:16:10.369Z" },
+    { url = "https://files.pythonhosted.org/packages/82/61/e59168d4d0bf2bf90f4f0caf7a001bfc60254c3af4586013b04dc3ef517b/librt-0.11.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:78dc31f7fdfe9c9d0eb0e8f42d139db230e826415bbcabd9f0e9faaaee909894", size = 144119, upload-time = "2026-05-10T18:16:11.771Z" },
+    { url = "https://files.pythonhosted.org/packages/61/fd/caa1d60b12f7dd79ccea23054e06eeaebe266a5f52c40a6b651069200ce5/librt-0.11.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:fa475675db22290c3158e1d42326d0f5a65f04f44a0e68c3630a25b53560fb9c", size = 143565, upload-time = "2026-05-10T18:16:13.334Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/a9/dc744f5c2b4978d48db970be29f22716d3413d28b14ad99740817315cf2c/librt-0.11.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:621db29691044bdeda22e789e482e1b0f3a985d90e3426c9c6d17606416205ea", size = 485395, upload-time = "2026-05-10T18:16:14.729Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/21/7f8e97a1e4dae952a5a95948f6f8507a173bc1e669f54340bba6ca1ca31b/librt-0.11.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:a9010e2ed5b3a9e158c5fd966b3ab7e834bb3d3aacc8f66c91dd4b57a3799230", size = 479383, upload-time = "2026-05-10T18:16:16.321Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/6d/d8ee9c114bebf2c50e29ec2aa940826fccb62a645c3e4c18760987d0e16d/librt-0.11.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7c39513d8b7477a2e1ed8c43fc21c524e8d5a0f8d4e8b7b074dbdbe7820a08e2", size = 513010, upload-time = "2026-05-10T18:16:17.647Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/43/0b5708af2bd30a46400e72ba6bdaa8f066f15fb9a688527e34220e8d6c06/librt-0.11.0-cp313-cp313-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:7aef3cf1d5af86e770ab04bfd993dfc4ae8b8c17f66fb77dd4a7d50de7bbb1a3", size = 508433, upload-time = "2026-05-10T18:16:19.309Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/50/356187247d09013490481033183b3532b58acf8028bcb34b2b56a375c9b2/librt-0.11.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:557183ddc36babe46b27dd60facbd5adb4492181a5be887587d57cda6e092f21", size = 522595, upload-time = "2026-05-10T18:16:20.642Z" },
+    { url = "https://files.pythonhosted.org/packages/40/e7/c6ac4240899c7f3248079d5a9900debe0dadb3fdeaf856684c987105ba47/librt-0.11.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:83d3e1f72bd42f6c5c0b7daec530c3f829bd02db42c70b8ddf0c2d90a2459930", size = 527255, upload-time = "2026-05-10T18:16:22.352Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/b5/a81322dbeedeeaf9c1ee6f001734d28a09d8383ac9e6779bc24bbd0743c6/librt-0.11.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:4ce1f21fbe589bc1afd7872dece84fb0e1144f794a288e58a10d2c54a55c43be", size = 516847, upload-time = "2026-05-10T18:16:23.627Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/66/6e6323787d592b55204a42595ff1102da5115601b53a7e9ddebc889a6da5/librt-0.11.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:970b09f7044ea2b64c9da42fd3d335666518cfd1c6e8a182c95da73d0214b41e", size = 553920, upload-time = "2026-05-10T18:16:25.025Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/21/623f8ca230857102066d9ca8c6c1734995908c4d0d1bee7bb2ef0021cb33/librt-0.11.0-cp313-cp313-win32.whl", hash = "sha256:78fddc31cd4d3caa897ad5d31f856b1faadc9474021ad6cb182b9018793e254e", size = 101898, upload-time = "2026-05-10T18:16:26.649Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/1d/b4ebd44dd723f768469007515cb92251e0ae286c94c140f374801140fa74/librt-0.11.0-cp313-cp313-win_amd64.whl", hash = "sha256:8ca8aa88751a775870b764e93bad5135385f563cb8dcee399abf034ea4d3cb47", size = 119812, upload-time = "2026-05-10T18:16:27.859Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/e4/b2f4ca7965ca373b491cdb4bc25cdb30c1649ca81a8782056a83850292a9/librt-0.11.0-cp313-cp313-win_arm64.whl", hash = "sha256:96f044bb325fd9cf1a723015638c219e9143f0dfbc0ca54c565df2b7fc748b44", size = 103448, upload-time = "2026-05-10T18:16:29.066Z" },
+    { url = "https://files.pythonhosted.org/packages/29/eb/dbce197da4e227779e56b5735f2decc3eb36e55a1cdbf1bd65d6639d76c1/librt-0.11.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:4a017a95e5837dc15a8c5661d60e05daa96b90908b1aa6b7acdf443cd25c8ebd", size = 143345, upload-time = "2026-05-10T18:16:30.674Z" },
+    { url = "https://files.pythonhosted.org/packages/76/a3/254bebd0c11c8ba684018efb8006ff22e466abce445215cca6c778e7d9de/librt-0.11.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:b1ecbd9819deccc39b7542bf4d2a740d8a620694d39989e58661d3763458f8d4", size = 143131, upload-time = "2026-05-10T18:16:32.037Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/3f/f77d6122d21ac7bf6ae8a7dfced1bd2a7ac545d3273ebdcaf8042f6d619f/librt-0.11.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7da327dacd7be8f8ec36547373550744a3cc0e536d54665cd83f8bcd961200e8", size = 477024, upload-time = "2026-05-10T18:16:33.493Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/0a/2c996dadebaa7d9bbbd43ef2d4f3e66b6da545f838a41694ef6172cebec8/librt-0.11.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:0dc56b1f8d06e60db362cc3fdae206681817f86ce4725d34511473487f12a34b", size = 474221, upload-time = "2026-05-10T18:16:34.864Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/7e/f5d92af8486b8272c23b3e686b46ff72d89c8169585eb61eef01a2ac7147/librt-0.11.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:05fb8fb2ab90e21c8d12ea240d744ad514da9baf381ebfa70d91d20d21713175", size = 505174, upload-time = "2026-05-10T18:16:36.705Z" },
+    { url = "https://files.pythonhosted.org/packages/af/1a/cb0734fe86398eb33193ab753b7326255c74cac5eb09e76b9b16536e7adb/librt-0.11.0-cp314-cp314-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:cae74872be221df4374d10fec61f93ed1513b9546ea84f2c0bf73ab3e9bd0b03", size = 497216, upload-time = "2026-05-10T18:16:38.418Z" },
+    { url = "https://files.pythonhosted.org/packages/18/06/094820f91558b66e29943c0ec41c9914f460f48dd51fc503c3101e10842d/librt-0.11.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:32bcc918c0148eb7e3d57385125bac7e5f9e4359d05f07448b09f6f778c2f31c", size = 513921, upload-time = "2026-05-10T18:16:39.848Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/c2/00de9018871a282f530cacb457d5ec0428f6ac7e6fedde9aff7468d9fb04/librt-0.11.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:f9743fc99135d5f78d2454435615f6dec0473ca507c26ce9d92b10b562a280d3", size = 520850, upload-time = "2026-05-10T18:16:41.471Z" },
+    { url = "https://files.pythonhosted.org/packages/51/9d/64631832348fd1834fb3a61b996434edddaaf25a31d03b0a76273159d2cf/librt-0.11.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:5ba067f4aadae8fda802d91d2124c90c42195ff32d9161d3549e6d05cfe26f96", size = 504237, upload-time = "2026-05-10T18:16:43.15Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/ec/ae5525eb16edc827a044e7bb8777a455ff95d4bca9379e7e6bddd7383647/librt-0.11.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:de3bf945454d032f9e390b85c4072e0a0570bf825421c8be0e71209fa65e1abe", size = 546261, upload-time = "2026-05-10T18:16:44.408Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/09/adce371f27ca039411da9659f7430fcc2ba6cd0c7b3e4467a0f091be7fa9/librt-0.11.0-cp314-cp314-win32.whl", hash = "sha256:d2277a05f6dcb9fd13db9566aac4fabd68c3ea1ea46ee5567d4eef8efa495a2f", size = 96965, upload-time = "2026-05-10T18:16:46.039Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/ee/8ac720d98548f173c7ce2e632a7ca94673f74cacd5c8162a84af5b35958a/librt-0.11.0-cp314-cp314-win_amd64.whl", hash = "sha256:ab73e8db5e3f564d812c1f5c3a175930a5f9bc96ccb5e3b22a34d7858b401cf7", size = 115151, upload-time = "2026-05-10T18:16:47.133Z" },
+    { url = "https://files.pythonhosted.org/packages/94/20/c900cf14efeb09b6bef2b2dff20779f73464b97fd58d1c6bccc379588ae3/librt-0.11.0-cp314-cp314-win_arm64.whl", hash = "sha256:aea3caa317752e3a466fa8af45d91ee0ea8c7fdd96e42b0a8dd9b76a7931eba1", size = 98850, upload-time = "2026-05-10T18:16:48.597Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/71/944bfe4b64e12abffcd3c15e1cce07f72f3d55655083786285f4dedeb532/librt-0.11.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:d1b36540d7aaf9b9101b3a6f376c8d8e9f7a9aec93ed05918f2c69d493ffef72", size = 151138, upload-time = "2026-05-10T18:16:49.839Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/10/99e64a5c86989357fda078c8143c533389585f6473b7439172dd8f3b3b2d/librt-0.11.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:efbb343ab2ce3540f4ecbe6315d677ed70f37cd9a72b1e58066c918ca83acbaa", size = 151976, upload-time = "2026-05-10T18:16:51.062Z" },
+    { url = "https://files.pythonhosted.org/packages/21/31/5072ad880946d83e5ea4147d6d018c78eefce85b77819b19bdd0ee229435/librt-0.11.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:aa0dd688aab3f7914d3e6e5e3554978e0383312fb8e771d84be008a35b9ee548", size = 557927, upload-time = "2026-05-10T18:16:52.632Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/8d/70b5fb7cfbab60edbe7381614ab985da58e144fbf465c86d44c95f43cdca/librt-0.11.0-cp314-cp314t-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:f5fb36b8c6c63fdcbb1d526d94c0d1331610d43f4118cc1beb4efef4f3faacb2", size = 539698, upload-time = "2026-05-10T18:16:53.934Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/a3/ba3495a0b3edbd24a4cae0d1d3c64f39a9fc45d06e812101289b50c1a619/librt-0.11.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4a9a237d13addb93715b6fee74023d5ee3469b53fce527626c0e088aa585805f", size = 577162, upload-time = "2026-05-10T18:16:55.589Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/db/36e25fb81f99937ff1b96612a1dc9fd66f039cb9cc3aee12c01fac31aab9/librt-0.11.0-cp314-cp314t-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:5ddd17bd87b2c56ddd60e546a7984a2e64c4e8eab92fb4cf3830a48ad5469d51", size = 566494, upload-time = "2026-05-10T18:16:56.975Z" },
+    { url = "https://files.pythonhosted.org/packages/33/0d/3f622b47f0b013eeb9cf4cc07ae9bfe378d832a4eec998b2b209fe84244d/librt-0.11.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bd43992b4473d42f12ff9e68326079f0696d9d4e6000e8f39a0238d482ba6ee2", size = 596858, upload-time = "2026-05-10T18:16:58.374Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/02/71b90bc93039c46a2000651f6ad60122b114c8f54c4ad306e0e96f5b75ad/librt-0.11.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:f8e3e8056dd674e279741485e2e512d6e9a751c7455809d0114e6ebf8d781085", size = 590318, upload-time = "2026-05-10T18:16:59.676Z" },
+    { url = "https://files.pythonhosted.org/packages/04/04/418cb3f75621e2b761fb1ab0f017f4d70a1a72a6e7c74ee4f7e8d198c2f3/librt-0.11.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:c1f708d8ae9c56cf38a903c44297243d2ec83fd82b396b977e0144a3e76217e3", size = 575115, upload-time = "2026-05-10T18:17:01.007Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/2c/5a2183ac58dd911f26b5d7e7d7d8f1d87fcecdddd99d6c12169a258ff62c/librt-0.11.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:0add982e0e7b9fc14cf4b33789d5f13f66581889b88c2f58099f6ce8f92617bd", size = 617918, upload-time = "2026-05-10T18:17:02.682Z" },
+    { url = "https://files.pythonhosted.org/packages/15/1f/dc6771a52592a4451be6effa200cbfc9cec61e4393d3033d81a9d307961d/librt-0.11.0-cp314-cp314t-win32.whl", hash = "sha256:2b481d846ac894c4e8403c5fd0e87c5d11d6499e404b474602508a224ff531c8", size = 103562, upload-time = "2026-05-10T18:17:03.99Z" },
+    { url = "https://files.pythonhosted.org/packages/62/4a/7d1415567027286a75ba1093ec4aca11f073e0f559c530cf3e0a757ad55c/librt-0.11.0-cp314-cp314t-win_amd64.whl", hash = "sha256:28edb433edde181112a908c78907af28f964eabc15f4dd16c9d66c834302677c", size = 124327, upload-time = "2026-05-10T18:17:05.465Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/62/b40b382fa0c66fee1478073eb8db352a4a6beda4a1adccf1df911d8c289c/librt-0.11.0-cp314-cp314t-win_arm64.whl", hash = "sha256:dee008f20b542e3cd162ba338a7f9ec0f6d23d395f66fe8aeeec3c9d067ea253", size = 102572, upload-time = "2026-05-10T18:17:06.809Z" },
+]
+
+[[package]]
 name = "line-profiler"
 version = "5.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1095,7 +1215,8 @@ name = "ml-dtypes"
 version = "0.4.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.13'",
+    "python_full_version >= '3.15'",
+    "python_full_version >= '3.13' and python_full_version < '3.15'",
 ]
 dependencies = [
     { name = "numpy", marker = "python_full_version >= '3.13'" },
@@ -1313,6 +1434,57 @@ wheels = [
 ]
 
 [[package]]
+name = "mypy"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ast-serialize" },
+    { name = "librt", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "mypy-extensions" },
+    { name = "pathspec" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/82/15/cca9d88503549ed6fedeaa1d448cdddd542ee8a490232d732e278036fbf2/mypy-2.1.0.tar.gz", hash = "sha256:81e76ad12c2d804512e9b13240d1588316531bfba07558286078bfbce9613633", size = 3898359, upload-time = "2026-05-11T18:37:36.237Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0a/a1/639f3024794a2a15899cb90707fe02e044c4412794c39c5769fd3df2e2ef/mypy-2.1.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:a683016b16fe2f572dc04c72be7ee0504ac1605a265d0200f5cea695fb788f41", size = 14691685, upload-time = "2026-05-11T18:33:27.973Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/08/9a585dea4325f20d8b80dc78623fa50d1fd2173b710f6237afd6ba6ab39b/mypy-2.1.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1a293c534adb55271fef24a26da04b855540a8c13cc07bc5917b9fd2c394f2ca", size = 13555165, upload-time = "2026-05-11T18:32:16.107Z" },
+    { url = "https://files.pythonhosted.org/packages/81/dc/7c42cc9c6cb01e8eb09961f1f738741d3e9c7e9d5c5b30ec69222625cd5f/mypy-2.1.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7406f4d048e71e576f5356d317e5b0a9e666dfd966bd99f9d14ca06e1a341538", size = 13994376, upload-time = "2026-05-11T18:32:39.256Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/fa/285946c33bce716e082c11dfeee9ee196eaf1f5042efb3581a31f9f205e4/mypy-2.1.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e0210d626fc8b31ccc90233754c7bc90e1f43205e85d96387f7db1285b55c398", size = 14864618, upload-time = "2026-05-11T18:34:49.765Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/83/82397f48af6c27e295d57979ded8490c9829040152cf7571b2f026aeb9a0/mypy-2.1.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:3712c20deed54e814eaaa825603bada8ea1c390670a397c95b98405347acc563", size = 15102063, upload-time = "2026-05-11T18:34:05.855Z" },
+    { url = "https://files.pythonhosted.org/packages/40/68/b02dec39057b88eb03dc0aa854732e26e8361f34f9d0e20c7614967d1eba/mypy-2.1.0-cp311-cp311-win_amd64.whl", hash = "sha256:fcaa0e479066e31f7cceb6a3bea39cb22b2ff51a6b2f24f193d19179ba17c389", size = 11060564, upload-time = "2026-05-11T18:35:36.494Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/a8/ea3dcbef31f99b634f2ee23bb0321cbc8c1b388b76a861eb849f13c347dc/mypy-2.1.0-cp311-cp311-win_arm64.whl", hash = "sha256:0b1a5260c95aa443083f9ed3592662941951bca3d4ca224a5dc517c38b7cf666", size = 9966983, upload-time = "2026-05-11T18:37:14.139Z" },
+    { url = "https://files.pythonhosted.org/packages/95/b1/55861beb5c339b44f9a2ba92df9e2cb1eeb4ae1eee674cdf7772c797778b/mypy-2.1.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:244358bf1c0da7722230bce60683d52e8e9fd030554926f15b747a84efb5b3af", size = 14874381, upload-time = "2026-05-11T18:37:31.784Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/b3/b7f770114b7d0ac92d0f76e8d93c2780844a70488a90e91821927850da86/mypy-2.1.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4ec7c57657493c7a75534df2751c8ae2cda383c16ecc55d2106c54476b1b16f6", size = 13665501, upload-time = "2026-05-11T18:34:23.063Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/f3/8ae2037967e2126689a0c11d99e2b707134a565191e92c60ca2572aec60a/mypy-2.1.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d8161b6ff4392410023224f0969d17db93e1e154bc3e4ba62598e720723ae211", size = 14045750, upload-time = "2026-05-11T18:31:48.151Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/32/615eb5911859e43d054941b0d0a7d06cfa2870eba86529cf385b052b111c/mypy-2.1.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bf03e12003084a67395184d3eb8cbd6a489dc3655b5664b28c210a9e2403ab0b", size = 15061630, upload-time = "2026-05-11T18:37:06.898Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/03/4eafbfff8bfab1b87082741eae6e6a624028c984e6708b73bce2a8570c9d/mypy-2.1.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:20509760fd791c51579d573153407d226385ec1f8bcce55d730b354f3336bc22", size = 15288831, upload-time = "2026-05-11T18:31:18.07Z" },
+    { url = "https://files.pythonhosted.org/packages/99/ee/919661478e5891a3c96e549c036e467e64563ab85995b10c53c8358e16a3/mypy-2.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:6753d0c1fdd6b1a23b9e4f283ce80b2153b724adcb2653b20b85a8a28ac6436b", size = 11135228, upload-time = "2026-05-11T18:34:31.23Z" },
+    { url = "https://files.pythonhosted.org/packages/24/0a/6a12b9782ca0831a553192f351679f4548abc9d19a7cc93bb7feb02084c7/mypy-2.1.0-cp312-cp312-win_arm64.whl", hash = "sha256:98ebb6589bb3b6d0c6f0c459d53ca55b8091fbc13d277c4041c885392e8195e8", size = 10040684, upload-time = "2026-05-11T18:36:48.199Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/dd/c7191469c777f07689c032a8f7326e393ea34c92d6d76eb7ce5ba57ea66d/mypy-2.1.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:35aac3bb114e03888f535d5eb51b8bafbb3266586b599da1940f9b1be3ec5bd5", size = 14852174, upload-time = "2026-05-11T18:31:38.929Z" },
+    { url = "https://files.pythonhosted.org/packages/55/8c/aed55408879043d72bb9135f4d0d19a02b886dd569631e113e3d2706cb8d/mypy-2.1.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8de55a8c861f2a49331f807be98d90caeceeef520bde13d43a160207f8af613e", size = 13651542, upload-time = "2026-05-11T18:36:04.636Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/8e/f371a824b1f1fa8ea6e3dbb8703d232977d572be2329554a3bc4d960302f/mypy-2.1.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5fdf2941a07434af755837d9880f7d7d25f1dacb1af9dcd4b9b66f2220a3024e", size = 14033929, upload-time = "2026-05-11T18:35:55.742Z" },
+    { url = "https://files.pythonhosted.org/packages/94/21/f54be870d6dd53a82c674407e0f8eed7174b05ec78d42e5abd7b42e84fd5/mypy-2.1.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e195b817c13f02352a9c124301f9f30f078405444679b6753c1b96b6eed37285", size = 15039200, upload-time = "2026-05-11T18:33:10.281Z" },
+    { url = "https://files.pythonhosted.org/packages/17/99/bf21748626a40ce59fd29a39386ab46afec88b7bd2f0fa6c3a97c995523f/mypy-2.1.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5431d42af987ebd92ba2f71d45c85ed41d8e6ca9f5fd209a69f68f707d2469e5", size = 15272690, upload-time = "2026-05-11T18:32:07.205Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/d7/9e90d2cf47100bea550ed2bc7b0d4de3a62181d84d5e37da0003e8462637/mypy-2.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:767fe8c66dc3e01e19e1737d4c38ebefead16125e1b8e58ad421903b376f5c65", size = 11147435, upload-time = "2026-05-11T18:33:56.477Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/46/e5c449e858798e35ffc90946282a27c62a77be743fe17480e4977374eb91/mypy-2.1.0-cp313-cp313-win_arm64.whl", hash = "sha256:ecfe70d43775ab99562ab128ce49854a362044c9f894961f68f898c23cb7429d", size = 10035052, upload-time = "2026-05-11T18:32:30.049Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/ca/b279a672e874aedd5498ae25f722dacc8aa86bbffb939b3f97cbb1cf6686/mypy-2.1.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:7354c5a7f69d9345c3d6e69921d57088eea3ddeeb6b20d34c1b3855b02c36ec2", size = 14848422, upload-time = "2026-05-11T18:35:45.984Z" },
+    { url = "https://files.pythonhosted.org/packages/27/e6/3efe56c631d959b9b4454e208b0ac4b7f4f58b404c89f8bec7b49efdfc21/mypy-2.1.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:49890d4f76ac9e06ec117f9e09f3174da70a620a0c300953d8595c926e80947f", size = 13677374, upload-time = "2026-05-11T18:36:57.188Z" },
+    { url = "https://files.pythonhosted.org/packages/84/7f/8107ea87a44fd1f1b59882442f033c9c3488c127201b1d1d15f1cbd6022e/mypy-2.1.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:761be68e023ef5d94678772396a8af1220030f80837a3afd8d0aef3b419666f4", size = 14055743, upload-time = "2026-05-11T18:35:18.361Z" },
+    { url = "https://files.pythonhosted.org/packages/51/4d/b6d34db183133b83761b9199a82d31557cdbb70a380d8c3b3438e11882a3/mypy-2.1.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c90345fc182dc363b891350457ec69c35140858538f38b4540845afcc32b1aef", size = 15020937, upload-time = "2026-05-11T18:34:59.618Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/d7/f08360c691d758acb02f45022c34d98b92892f4ea756644e1000d4b9f3d8/mypy-2.1.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:b84802e7b5a6daf1f5e15bc9fcd7ddae77be13981ffab037f1c67bb84d67d135", size = 15253371, upload-time = "2026-05-11T18:36:41.081Z" },
+    { url = "https://files.pythonhosted.org/packages/67/1b/09460a13719530a19bce27bd3bc8449e83569dd2ba7faf51c9c3c30c0b61/mypy-2.1.0-cp314-cp314-win_amd64.whl", hash = "sha256:022c771234936ceac541ebaf836fe9e2abeb3f5e09aff21588fe543ff006fe21", size = 11326429, upload-time = "2026-05-11T18:34:13.526Z" },
+    { url = "https://files.pythonhosted.org/packages/40/62/75dbf0f82f7b6680340efc614af29dd0b3c17b8a4f1cd09b8bd2fd6bc814/mypy-2.1.0-cp314-cp314-win_arm64.whl", hash = "sha256:498207db725cec88829a6a5c2fc771205fd043719ef98bc49aba8fb9fc4e6d57", size = 10218799, upload-time = "2026-05-11T18:32:23.491Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/66/caca04ed7d972fb6eb6dd1ccd6df1de5c38fae8c5b3dc1c4e8e0d85ee6b9/mypy-2.1.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:7d5e5cad0efeba72b93cd17490cc0d69c5ac9ca132994fe3fb0314808aeeb83e", size = 15923458, upload-time = "2026-05-11T18:35:28.64Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/52/2d90cbe49d014b13ed7ff337930c30bad35893fe38a1e4641e756bb62191/mypy-2.1.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ff715050c127d724fd260a2e666e7747fdd83511c0c47d449d98238970aef780", size = 14757697, upload-time = "2026-05-11T18:36:14.208Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/37/d98f4a14e081b238992d0ed96b6d39c7cc0148c9699eb71eaa68629665ea/mypy-2.1.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:82208da9e09414d520e912d3e462d454854bed0810b71540bb016dcbca7308fd", size = 15405638, upload-time = "2026-05-11T18:33:48.249Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/c2/15c46613b24a84fad2aea1248bf9619b99c2767ae9071fe224c179a0b7d4/mypy-2.1.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e79ebc1b904b84f0310dff7469655a9c36c7a68bddb37bdd42b67a332df61d08", size = 16215852, upload-time = "2026-05-11T18:32:50.296Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/90/9c16a57f482c76d25f6379762b56bbf65c711d8158cf271fb2802cfb0640/mypy-2.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:e583edc957cfb0deb142079162ae826f58449b116c1d442f2d91c69d9fced081", size = 16452695, upload-time = "2026-05-11T18:33:38.182Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/4c/215a4eeb63cacc5f17f516691ea7285d11e249802b942476bff15922a314/mypy-2.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b33b6cd332695bba180d55e717a79d3038e479a2c49cc5eb3d53603409b9a5d7", size = 12866622, upload-time = "2026-05-11T18:34:39.945Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/50/1043e1db5f455ffe4c9ab22747cd8ca2bc492b1e4f4e21b130a44ee2b217/mypy-2.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:4f910fe825376a7b66ef7ca8c98e5a149e8cd64c19ae71d84047a74ee060d4e6", size = 10610798, upload-time = "2026-05-11T18:36:31.444Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/2a/13ca1f292f6db1b98ff495ef3467736b331621c5917cad984b7043e7348d/mypy-2.1.0-py3-none-any.whl", hash = "sha256:a663814603a5c563fb87a4f96fb473eeb30d1f5a4885afcf44f9db000a366289", size = 2693302, upload-time = "2026-05-11T18:31:29.246Z" },
+]
+
+[[package]]
 name = "mypy-extensions"
 version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1386,7 +1558,8 @@ name = "onnx"
 version = "1.19.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.13'",
+    "python_full_version >= '3.15'",
+    "python_full_version >= '3.13' and python_full_version < '3.15'",
 ]
 dependencies = [
     { name = "ml-dtypes", version = "0.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
@@ -1577,11 +1750,11 @@ wheels = [
 
 [[package]]
 name = "pathspec"
-version = "0.12.1"
+version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ca/bc/f35b8446f4531a7cb215605d100cd88b7ac6f44ab3fc94870c120ab3adbf/pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712", size = 51043, upload-time = "2023-12-10T22:30:45Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cc/20/ff623b09d963f88bfde16306a54e12ee5ea43e9b597108672ff3a408aad6/pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08", size = 31191, upload-time = "2023-12-10T22:30:43.14Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
 ]
 
 [[package]]
@@ -2190,6 +2363,7 @@ dependencies = [
     { name = "biopython" },
     { name = "click" },
     { name = "click-aliases" },
+    { name = "crcmod" },
     { name = "cython" },
     { name = "datasets" },
     { name = "fastjsonschema" },
@@ -2233,9 +2407,11 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "black" },
+    { name = "crcmod" },
     { name = "isort" },
     { name = "line-profiler" },
     { name = "maturin" },
+    { name = "mypy" },
     { name = "pytest" },
 ]
 
@@ -2246,6 +2422,7 @@ requires-dist = [
     { name = "biopython", specifier = ">=1.81" },
     { name = "click", specifier = ">=8.1.3" },
     { name = "click-aliases", specifier = ">=1.0.1" },
+    { name = "crcmod", specifier = ">=1.7" },
     { name = "cython", specifier = ">=3.1.2" },
     { name = "datasets", specifier = ">=3.5.0" },
     { name = "fastjsonschema", specifier = ">=2.21.2" },
@@ -2289,9 +2466,11 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "black", specifier = ">=24.4.2" },
+    { name = "crcmod", specifier = ">=1.7" },
     { name = "isort", specifier = ">=5.13.2" },
     { name = "line-profiler", specifier = ">=5.0.0" },
     { name = "maturin", specifier = ">=1.10" },
+    { name = "mypy", specifier = ">=1.20.2" },
     { name = "pytest", specifier = ">=7.2.0" },
 ]
 

--- a/workflows/databases/ena.nf
+++ b/workflows/databases/ena.nf
@@ -27,7 +27,7 @@ process fetch_directory {
   tuple val(name), val(remotes)
 
   output:
-  path("${name}-chunks/*.ncr")
+  path("${name}-chunks/*.ncr"), optional: true
 
   """
   rsync \
@@ -40,15 +40,19 @@ process fetch_directory {
     ${remotes.join(' ')} "copied"
 
   find copied -type f -empty -delete
-  find copied -type f -name '*.gz' | xargs -I {} gzip --quiet -l {} | awk '{ if (\$2 == 0) print \$4 }' | xargs -I {} rm {}.gz
+  find copied -type f -name '*.gz' | xargs -r -I {} gzip --quiet -l {} | awk '{ if (\$2 == 0) print \$4 }' | xargs -r -I {} rm {}.gz
 
   pushd copied
-  find . -type f -name '*.tar' | xargs -I {} tar -xvf {}
+  find . -type f -name '*.tar' | xargs -r -I {} tar -xvf {}
   popd
-  find copied -type f -name '*.ncr.gz' | xargs zcat > ${name}.ncr
+  find copied -type f -name '*.ncr.gz' | xargs -r zcat > ${name}.ncr
 
   mkdir $name-chunks
-  split-ena --max-sequences ${params.databases.ena.max_sequences} ${name}.ncr ${name}-chunks
+  if [ -s ${name}.ncr ]; then
+    split-ena --max-sequences ${params.databases.ena.max_sequences} ${name}.ncr ${name}-chunks
+  else
+    echo "No .ncr data fetched for ${name} batch; emitting no chunks" >&2
+  fi
   """
 }
 

--- a/workflows/databases/ena.nf
+++ b/workflows/databases/ena.nf
@@ -12,7 +12,7 @@ process list_subdirs {
   tuple val(name), path("${name}-dirs.txt")
 
   """
-  find -L ${path} -mindepth 1 -maxdepth 1 -type d > ${name}-dirs.txt
+  find -L ${path} -mindepth 1 -maxdepth 1 -type d -printf '%s\\t%p\\n' > ${name}-dirs.txt
   """
 }
 
@@ -109,10 +109,27 @@ workflow ena {
     ]) \
     | list_subdirs \
     | flatMap { name, listing ->
-        listing.readLines()
-          .findAll { it.trim() }
-          .collate( params.databases.ena.subdir_batch_size )
-          .collect { batch -> [name, batch.collect { it.trim() }] }
+        // Greedy bin-pack subdirs into batches by inode-size weight (a cheap
+        // proxy for entry count), so a few huge subdirs don't make some tasks
+        // far heavier than others. A subdir larger than the budget lands in a
+        // batch of its own.
+        long budget = params.databases.ena.subdir_batch_bytes as long
+        def batches = []
+        def cur = []
+        long curBytes = 0
+        listing.readLines().findAll { it.trim() }.each { line ->
+          def (sz, dir) = line.split('\t', 2)
+          long bytes = sz as long
+          if (cur && curBytes + bytes > budget) {
+            batches << [name, cur]
+            cur = []
+            curBytes = 0
+          }
+          cur << dir
+          curBytes += bytes
+        }
+        if (cur) batches << [name, cur]
+        return batches
       } \
     | set { subdir_batches }
 

--- a/workflows/databases/ena.nf
+++ b/workflows/databases/ena.nf
@@ -12,7 +12,7 @@ process list_subdirs {
   tuple val(name), path("${name}-dirs.txt")
 
   """
-  find -L ${path} -mindepth 1 -maxdepth 1 -type d -printf '%s\\t%p\\n' > ${name}-dirs.txt
+  find -L ${path} -mindepth 1 -maxdepth 1 -type d > ${name}-dirs.txt
   """
 }
 
@@ -109,27 +109,10 @@ workflow ena {
     ]) \
     | list_subdirs \
     | flatMap { name, listing ->
-        // Greedy bin-pack subdirs into batches by inode-size weight (a cheap
-        // proxy for entry count), so a few huge subdirs don't make some tasks
-        // far heavier than others. A subdir larger than the budget lands in a
-        // batch of its own.
-        long budget = params.databases.ena.subdir_batch_bytes as long
-        def batches = []
-        def cur = []
-        long curBytes = 0
-        listing.readLines().findAll { it.trim() }.each { line ->
-          def (sz, dir) = line.split('\t', 2)
-          long bytes = sz as long
-          if (cur && curBytes + bytes > budget) {
-            batches << [name, cur]
-            cur = []
-            curBytes = 0
-          }
-          cur << dir
-          curBytes += bytes
-        }
-        if (cur) batches << [name, cur]
-        return batches
+        listing.readLines()
+          .findAll { it.trim() }
+          .collate( params.databases.ena.subdir_batch_size )
+          .collect { batch -> [name, batch.collect { it.trim() }] }
       } \
     | set { subdir_batches }
 

--- a/workflows/databases/ena.nf
+++ b/workflows/databases/ena.nf
@@ -74,6 +74,7 @@ process fetch_metadata {
 process process_file {
   memory '8GB'
   tag { "$raw" }
+  time '10m'
 
   input:
   tuple path(raw), path(tpa), path(model_lengths)

--- a/workflows/databases/ena.nf
+++ b/workflows/databases/ena.nf
@@ -1,3 +1,21 @@
+process list_subdirs {
+  tag { "$name" }
+  when { params.databases.ena.run }
+  queue 'datamover'
+  containerOptions "${params.common_container} --bind /nfs:/nfs"
+  time '1h'
+
+  input:
+  tuple val(name), val(path)
+
+  output:
+  tuple val(name), path("${name}-dirs.txt")
+
+  """
+  find -L ${path} -mindepth 1 -maxdepth 1 -type d > ${name}-dirs.txt
+  """
+}
+
 process fetch_directory {
   tag { "$name" }
   when { params.databases.ena.run }
@@ -6,20 +24,20 @@ process fetch_directory {
   time '2d'
 
   input:
-  tuple val(name), val(remote)
+  tuple val(name), val(remotes)
 
   output:
   path("${name}-chunks/*.ncr")
 
   """
   rsync \
-    -avPL \
+    -aL --partial \
     --prune-empty-dirs \
     --include='*/' \
     --include='**/*.ncr.gz' \
     --include='**/*.tar' \
     --exclude='*.fasta.gz' \
-    "$remote" "copied"
+    ${remotes.join(' ')} "copied"
 
   find copied -type f -empty -delete
   find copied -type f -name '*.gz' | xargs -I {} gzip --quiet -l {} | awk '{ if (\$2 == 0) print \$4 }' | xargs -I {} rm {}.gz
@@ -80,12 +98,24 @@ workflow ena {
     fetch_metadata(urls) | set { metadata }
 
     Channel.fromList([
-      ['con', "$params.databases.ena.remote/con/"],
-      ['std', "$params.databases.ena.remote/std/"],
+      ['wgs', "$params.databases.ena.remote/wgs/"],
       ['tls', "$params.databases.ena.remote/tls/"],
       ['tsa', "$params.databases.ena.remote/tsa/"],
-      ['wgs', "$params.databases.ena.remote/wgs/"],
     ]) \
+    | list_subdirs \
+    | flatMap { name, listing ->
+        listing.readLines()
+          .findAll { it.trim() }
+          .collate( params.databases.ena.subdir_batch_size )
+          .collect { batch -> [name, batch.collect { it.trim() }] }
+      } \
+    | set { subdir_batches }
+
+    Channel.fromList([
+      ['con', ["$params.databases.ena.remote/con/"]],
+      ['std', ["$params.databases.ena.remote/std/"]],
+    ]) \
+    | mix( subdir_batches ) \
     | fetch_directory \
     | flatten \
     | combine(metadata) \


### PR DESCRIPTION
This does the following:

- Use set for membership checking in ENA DR parsing - rather than membership of the SqliteDict
- Reorder comment parsing for faster short circuiting
- Remove unnecessary converters (str -> str on things we want to break if they aren't str)
- Keep xrefs in memory unless there are too many, then spill to an SqliteDict on disk to handle the massive ones
- Slots & caching on some key dataclasses/ID lookups
- Switch to a faster C implementation of the CRC64 checksum via crcmod with explicit polynomial to match existing CRCs (checked on 50k ENA sequences)

Overall, improves performance on ENA parsing (for the one chunk I tried) by ~3x. Local parse time from 45s ->14s. Outputs match, though I haven't tried to load anything yet

Some changes will touch other places and may speed up those parsers too. The potential widespread impact is the reason for marking this experimental, but I'm quite confident it won't break things. A test may be to dump a larger selection of sequences from the database and verify the CRCs on a much larger set.

The memory threshold for spilling to disk is 1GB of string characters, which I think is ~5GB of real RAM. That's tunable, but the parser process has 8GB requested so I'm hoping it will be ok.