### PR TITLE
Improvement/update nextflow version

### DIFF
--- a/analyze.nf
+++ b/analyze.nf
@@ -27,7 +27,7 @@ workflow {
       def msg = workflow?.success ? "Analyze workflow completed" : "Analyze workflow completed with errors"
       slack_closure(msg)
     } catch (Exception e) {
-      log.warn "Could not send Slack notification: ${e.message}"
+      log.warn "Could not send Slack notification: ${e}"
     }
   }
 
@@ -35,7 +35,7 @@ workflow {
     try {
       slack_closure("Analyze workflow hit an error and crashed")
     } catch (Exception e) {
-      log.warn "Could not send Slack notification: ${e.message}"
+      log.warn "Could not send Slack notification: ${e}"
     }
   }
 }

--- a/analyze.nf
+++ b/analyze.nf
@@ -20,22 +20,21 @@ workflow analyze {
 }
 
 workflow {
-  analyze(channel.of('ready'))
+  main:
+    analyze(channel.of('ready'))
 
-  workflow.onComplete {
+  onComplete:
     try {
-      def msg = workflow?.success ? "Analyze workflow completed" : "Analyze workflow completed with errors"
+      def msg = workflow.success ? "Analyze workflow completed" : "Analyze workflow completed with errors"
       slack_closure(msg)
     } catch (Exception e) {
       log.warn "Could not send Slack notification: ${e}"
     }
-  }
 
-  workflow.onError {
+  onError:
     try {
       slack_closure("Analyze workflow hit an error and crashed")
     } catch (Exception e) {
       log.warn "Could not send Slack notification: ${e}"
     }
-  }
 }

--- a/analyze.nf
+++ b/analyze.nf
@@ -15,12 +15,12 @@ include { slack_message } from './workflows/utils/slack'
 workflow analyze {
   take: ready
   main:
-    Channel.of("Starting analyze pipeline") | slack_message
+    channel.of("Starting analyze pipeline") | slack_message
     ready | (genome_mapping & rfam_scan & r2dt & cpat & tcode & stopfree )
 }
 
 workflow {
-  analyze(Channel.of('ready'))
+  analyze(channel.of('ready'))
 
   workflow.onComplete {
     try {

--- a/config/databases.config
+++ b/config/databases.config
@@ -60,6 +60,12 @@ params {
     }
 
     ensembl {
+      // Set from main.nf: true if any ensembl division is configured to run.
+      // Declared here so the key exists (main.nf cannot vivify it on a plain map).
+      _any {
+        run = false
+      }
+
       gencode {
         ftp_host = 'ftp.ebi.ac.uk'
       }

--- a/config/export.config
+++ b/config/export.config
@@ -6,7 +6,7 @@ params {
       schema = 'http://www.ebi.ac.uk/ebisearch/XML4dbDumps.xsd'
       publish {
         host = ""
-        path = "${projectDir}/search-export"
+        path = "${baseDir}/search-export"
       }
       memory = 16.GB
     }
@@ -17,7 +17,7 @@ params {
 
       publish {
         host = ""
-        path = "${projectDir}/sequence-search-export"
+        path = "${baseDir}/sequence-search-export"
       }
 
       create_fasta {
@@ -33,7 +33,7 @@ params {
 
     ftp {
       run= true
-      publish = "${projectDir}/ftp"
+      publish = "${baseDir}/ftp"
       id_mapping {
         run = true
         by_database.run = true

--- a/config/export.config
+++ b/config/export.config
@@ -6,7 +6,7 @@ params {
       schema = 'http://www.ebi.ac.uk/ebisearch/XML4dbDumps.xsd'
       publish {
         host = ""
-        path = "${baseDir}/search-export"
+        path = "${projectDir}/search-export"
       }
       memory = 16.GB
     }
@@ -17,7 +17,7 @@ params {
 
       publish {
         host = ""
-        path = "${baseDir}/sequence-search-export"
+        path = "${projectDir}/sequence-search-export"
       }
 
       create_fasta {
@@ -33,7 +33,7 @@ params {
 
     ftp {
       run= true
-      publish = "${baseDir}/ftp"
+      publish = "${projectDir}/ftp"
       id_mapping {
         run = true
         by_database.run = true

--- a/config/main.config
+++ b/config/main.config
@@ -1,7 +1,7 @@
 params {
   notify = false
   notify_url = ""
-  connection_file = "$baseDir/config/databases.json"
+  connection_file = "$projectDir/config/databases.json"
 
   import_data {
     chunk_size = 256 * 1000 * 1000

--- a/config/main.config
+++ b/config/main.config
@@ -1,7 +1,7 @@
 params {
   notify = false
   notify_url = ""
-  connection_file = "$projectDir/config/databases.json"
+  connection_file = "$baseDir/config/databases.json"
 
   import_data {
     chunk_size = 256 * 1000 * 1000

--- a/config/main.config
+++ b/config/main.config
@@ -1,10 +1,7 @@
-def slurper = new groovy.json.JsonSlurper()
-
 params {
   notify = false
   notify_url = ""
   connection_file = "$baseDir/config/databases.json"
-  connections = slurper.parse(new File(connection_file))
 
   import_data {
     chunk_size = 256 * 1000 * 1000

--- a/config/r2dt.config
+++ b/config/r2dt.config
@@ -6,9 +6,9 @@ params {
     sequence_chunk_size = 100
     sequence_count = 2000000
     tablename = 'traveler_sequences_to_analyze'
-    publish = "$baseDir/r2dt"
+    publish = "$projectDir/r2dt"
     container = 'rnacentral/r2dt:develop'
-    cms_path = "$baseDir/singularity/bind/r2dt/data/cms"
+    cms_path = "$projectDir/singularity/bind/r2dt/data/cms"
 
     find_possible {
       memory = '4GB'

--- a/config/r2dt.config
+++ b/config/r2dt.config
@@ -6,9 +6,9 @@ params {
     sequence_chunk_size = 100
     sequence_count = 2000000
     tablename = 'traveler_sequences_to_analyze'
-    publish = "$projectDir/r2dt"
+    publish = "$baseDir/r2dt"
     container = 'rnacentral/r2dt:develop'
-    cms_path = "$projectDir/singularity/bind/r2dt/data/cms"
+    cms_path = "$baseDir/singularity/bind/r2dt/data/cms"
 
     find_possible {
       memory = '4GB'

--- a/config/stopfree.config
+++ b/config/stopfree.config
@@ -12,5 +12,5 @@ params {
 }
 
 process {
-  maxForks = 2000
+  maxForks = params.stopfree.max_forks
 }

--- a/config/stopfree.config
+++ b/config/stopfree.config
@@ -12,5 +12,5 @@ params {
 }
 
 process {
-  maxForks = params.stopfree.max_forks
+  maxForks = 2000
 }

--- a/config/tcode.config
+++ b/config/tcode.config
@@ -13,5 +13,5 @@ params {
 }
 
 process {
-  maxForks = params.tcode.max_forks
+  maxForks = 3500
 }

--- a/config/tcode.config
+++ b/config/tcode.config
@@ -13,5 +13,5 @@ params {
 }
 
 process {
-  maxForks = 3500
+  maxForks = params.tcode.max_forks
 }

--- a/export.nf
+++ b/export.nf
@@ -14,5 +14,5 @@ workflow export {
 }
 
 workflow {
-  export(Channel.of('ready'))
+  export(channel.of('ready'))
 }

--- a/export.nf
+++ b/export.nf
@@ -2,8 +2,8 @@
 
 nextflow.enable.dsl=2
 
-include { text_search } from './workflows/export/text-search'
-include { ftp } from './workflows/export/ftp'
+include { text_search } from './workflows/export/text-search.nf'
+include { ftp } from './workflows/export/ftp.nf'
 include { sequence_search } from './workflows/export/sequence-search'
 
 workflow export {

--- a/genes.nf
+++ b/genes.nf
@@ -239,13 +239,13 @@ process store_metadata {
 workflow genes {
   // _flag is an ordering trigger so this stage can be chained after upstream
   // stages in main.nf. It is not otherwise used: the pipeline is driven by
-  // params.genes. Standalone runs pass Channel.of(true) (see entry below).
+  // params.genes. Standalone runs pass channel.of(true) (see entry below).
   take: _flag
 
   main:
-  Channel.of(true) | fetch_so_model | set { so_model }
-  Channel.of(true) | fetch_rf_model | set { rf_model }
-  Channel.fromPath(params.genes.taxa_query) | fetch_taxids | set { taxa }
+  channel.of(true) | fetch_so_model | set { so_model }
+  channel.of(true) | fetch_rf_model | set { rf_model }
+  channel.fromPath(params.genes.taxa_query) | fetch_taxids | set { taxa }
 
   taxa \
   | splitCsv \
@@ -291,5 +291,5 @@ workflow genes {
 
 
 workflow {
-  genes(Channel.of(true))
+  genes(channel.of(true))
 }

--- a/import-crs.nf
+++ b/import-crs.nf
@@ -2,10 +2,10 @@
 
 process fetch_crs_bed {
   input:
-  val(remote) from channel.from(params.crs.path)
+  val(remote)
 
   output:
-  file('*.bed') into raw_crs mode flatten
+  path('*.bed')
 
   script:
   """
@@ -14,31 +14,14 @@ process fetch_crs_bed {
   """
 }
 
-raw_crs
-  .map { f ->
-    def assembly =  file(f).name
-      .replace("cmf_extend.", "")
-      .replace(".fdr10.nonredundant.bed", "")
-    [ assembly, f ]
-  }
-  .into { crs_bed_with_assemblies; pre_fetch }
-
-pre_fetch
-  .map { assembly, _ver -> [assembly, params.crs.assembly_rnacentral_mapping[assembly]] }
-  .into { for_rfam_fetch; for_rnacentral_fetch }
-
-for_rfam_fetch
-  .combine(channel.fromPath("files/crs/fetch-rfam.sql"))
-  .set { rfam_to_fetch }
-
 process fetch_rfam_locations {
   maxForks 4
 
   input:
-  set val(crs_assembly), val(assembly), file(query) from rfam_to_fetch
+  tuple val(crs_assembly), val(assembly), path(query)
 
   output:
-  set val(crs_assembly), file("rfam-${assembly}.bed") into rfam_coordinates
+  tuple val(crs_assembly), path("rfam-${assembly}.bed")
 
   script:
   """
@@ -48,18 +31,14 @@ process fetch_rfam_locations {
   """
 }
 
-for_rnacentral_fetch
-  .combine(channel.fromPath("files/crs/fetch-rnacentral.sql"))
-  .set { rnacentral_assemblies_to_fetch }
-
 process fetch_rnacentral_bed {
   maxForks 4
 
   input:
-  set val(crs_assembly), val(assembly), file(query) from rnacentral_assemblies_to_fetch
+  tuple val(crs_assembly), val(assembly), path(query)
 
   output:
-  set val(crs_assembly), file("rnacentral-${assembly}.bed") into rnacentral_locations
+  tuple val(crs_assembly), path("rnacentral-${assembly}.bed")
 
   script:
   """
@@ -69,17 +48,12 @@ process fetch_rnacentral_bed {
   """
 }
 
-crs_bed_with_assemblies
-  .join(rfam_coordinates)
-  .join(rnacentral_locations)
-  .set { crs_to_clean }
-
 process find_rnacentral_crs_features {
   input:
-  set val(assembly), file(crs), file(rfam), file(rnacentral) from crs_to_clean
+  tuple val(assembly), path(crs), path(rfam), path(rnacentral)
 
   output:
-  file('complete_features.csv') into processed_crs
+  path('complete_features.csv')
 
   script:
   def must_clean = params.crs.must_clean_bed.contains(assembly) ? '1' : '0';
@@ -91,12 +65,42 @@ process find_rnacentral_crs_features {
 
 process import_crs {
   input:
-  file('complete_features*.csv') from processed_crs.collect()
-  file(ctl) from channel.fromPath('files/crs/load.ctl')
+  path('complete_features*.csv')
+  path(ctl)
 
   script:
   """
   cp $ctl crs.ctl
   pgloader --on-error-stop crs.ctl
   """
+}
+
+workflow {
+  crs_bed_with_assemblies = fetch_crs_bed(channel.of(params.crs.path))
+    | flatten
+    | map { f ->
+        def assembly = file(f).name
+          .replace("cmf_extend.", "")
+          .replace(".fdr10.nonredundant.bed", "")
+        [ assembly, f ]
+      }
+
+  pre_fetch = crs_bed_with_assemblies
+    .map { assembly, _f -> [assembly, params.crs.assembly_rnacentral_mapping[assembly]] }
+
+  rfam_coordinates = fetch_rfam_locations(
+    pre_fetch.combine(channel.fromPath("files/crs/fetch-rfam.sql"))
+  )
+
+  rnacentral_locations = fetch_rnacentral_bed(
+    pre_fetch.combine(channel.fromPath("files/crs/fetch-rnacentral.sql"))
+  )
+
+  crs_to_clean = crs_bed_with_assemblies
+    .join(rfam_coordinates)
+    .join(rnacentral_locations)
+
+  processed_crs = find_rnacentral_crs_features(crs_to_clean)
+
+  import_crs(processed_crs.collect(), channel.fromPath('files/crs/load.ctl'))
 }

--- a/import-crs.nf
+++ b/import-crs.nf
@@ -2,7 +2,7 @@
 
 process fetch_crs_bed {
   input:
-  val(remote) from Channel.from(params.crs.path)
+  val(remote) from channel.from(params.crs.path)
 
   output:
   file('*.bed') into raw_crs mode flatten
@@ -28,7 +28,7 @@ pre_fetch
   .into { for_rfam_fetch; for_rnacentral_fetch }
 
 for_rfam_fetch
-  .combine(Channel.fromPath("files/crs/fetch-rfam.sql"))
+  .combine(channel.fromPath("files/crs/fetch-rfam.sql"))
   .set { rfam_to_fetch }
 
 process fetch_rfam_locations {
@@ -49,7 +49,7 @@ process fetch_rfam_locations {
 }
 
 for_rnacentral_fetch
-  .combine(Channel.fromPath("files/crs/fetch-rnacentral.sql"))
+  .combine(channel.fromPath("files/crs/fetch-rnacentral.sql"))
   .set { rnacentral_assemblies_to_fetch }
 
 process fetch_rnacentral_bed {
@@ -92,7 +92,7 @@ process find_rnacentral_crs_features {
 process import_crs {
   input:
   file('complete_features*.csv') from processed_crs.collect()
-  file(ctl) from Channel.fromPath('files/crs/load.ctl')
+  file(ctl) from channel.fromPath('files/crs/load.ctl')
 
   script:
   """

--- a/import-data.nf
+++ b/import-data.nf
@@ -41,21 +41,20 @@ workflow import_data {
 }
 
 workflow {
-  import_data(channel.of('ready'))
+  main:
+    import_data(channel.of('ready'))
 
-  workflow.onError {
+  onComplete:
+    try {
+      slack_closure("Workflow completed ${workflow.success ? 'Ok' : 'with errors'}")
+    } catch (Exception e) {
+      log.warn "Could not send Slack notification: ${e}"
+    }
+
+  onError:
     try {
       slack_closure("Import pipeline encountered an error and failed")
     } catch (Exception e) {
       log.warn "Could not send Slack notification: ${e}"
     }
-  }
-
-  workflow.onComplete {
-    try {
-      slack_closure("Workflow completed ${workflow?.success ? 'Ok' : 'with errors'}")
-    } catch (Exception e) {
-      log.warn "Could not send Slack notification: ${e}"
-    }
-  }
 }

--- a/import-data.nf
+++ b/import-data.nf
@@ -13,9 +13,9 @@ include { slack_closure } from './workflows/utils/slack'
 workflow import_data {
   take: _flag
   main:
-    Channel.of("Starting data import pipeline") | slack_message
+    channel.of("Starting data import pipeline") | slack_message
 
-    Channel.empty() \
+    channel.empty() \
     | mix(
       parse_databases(),
       parse_metadata(),
@@ -41,7 +41,7 @@ workflow import_data {
 }
 
 workflow {
-  import_data(Channel.of('ready'))
+  import_data(channel.of('ready'))
 
   workflow.onError {
     try {

--- a/import-data.nf
+++ b/import-data.nf
@@ -47,7 +47,7 @@ workflow {
     try {
       slack_closure("Import pipeline encountered an error and failed")
     } catch (Exception e) {
-      log.warn "Could not send Slack notification: ${e.message}"
+      log.warn "Could not send Slack notification: ${e}"
     }
   }
 
@@ -55,7 +55,7 @@ workflow {
     try {
       slack_closure("Workflow completed ${workflow?.success ? 'Ok' : 'with errors'}")
     } catch (Exception e) {
-      log.warn "Could not send Slack notification: ${e.message}"
+      log.warn "Could not send Slack notification: ${e}"
     }
   }
 }

--- a/import-data.nf
+++ b/import-data.nf
@@ -20,9 +20,9 @@ workflow import_data {
       parse_databases(),
       parse_metadata(),
     ) \
-    | branch {
-      terms: it.name == "terms.csv"
-      ref_ids: it.name == "ref_ids.csv"
+    | branch { r ->
+      terms: r.name == "terms.csv"
+      ref_ids: r.name == "ref_ids.csv"
       csv: true
     } \
     | set { results }

--- a/main.nf
+++ b/main.nf
@@ -22,7 +22,7 @@ def willRun(key, db) {
 // which are permitted at the top level).
 params.databases.ensembl._any.run =
   ['vertebrates', 'plants', 'fungi', 'protists', 'metazoa'].any { d -> params.databases.ensembl[d]?.get('run', false) }
-params.needs_publications = params.databases.any { key, db -> willRun(key, db) }
+params.needs_publications = !params.get('skip_publications', false) && params.databases.any { key, db -> willRun(key, db) }
 params.should_release     = params.databases.any { key, db -> willRun(key, db) && db.get('release', true) }
 params.needs_taxonomy     = params.databases.any { key, db -> willRun(key, db) && db.get('needs_taxonomy', false) }
 

--- a/main.nf
+++ b/main.nf
@@ -6,31 +6,25 @@ nextflow.enable.dsl = 2
 // main.config, but Nextflow 26+ forbids variable declarations in config files.
 params.connections = new groovy.json.JsonSlurper().parse(new File(params.connection_file))
 
-// Infer needs_publications, should_release, and needs_taxonomy from which
-// databases are configured to run. Previously a for loop in nextflow.config,
-// which Nextflow 26+ no longer supports in config files.
-for (item in params.databases) {
-  def db = item.value;
-  def will_run = db.get('run', false);
-  if (item.key == 'ensembl') {
-    def ensembl_will_run = ['vertebrates', 'plants', 'fungi', 'protists', 'metazoa'].any {
-      db[it]?.get('run', false)
-    }
-    will_run = ensembl_will_run
-    if (ensembl_will_run) {
-      params.databases.ensembl._any.run = ensembl_will_run
-    }
+// Whether a database entry is configured to run. Ensembl is special-cased: it
+// runs if any of its divisions do.
+def willRun(key, db) {
+  if (key == 'ensembl') {
+    return ['vertebrates', 'plants', 'fungi', 'protists', 'metazoa'].any { db[it]?.get('run', false) }
   }
-  if (will_run) {
-    params.needs_publications = true;
-    if (db.get('release', true)) {
-      params.should_release = true;
-    }
-    if (db.get('needs_taxonomy', false)) {
-      params.needs_taxonomy = true
-    }
-  }
+  return db.get('run', false)
 }
+
+// Infer needs_publications, should_release, and needs_taxonomy from which
+// databases are configured to run. Previously a for loop in nextflow.config;
+// Nextflow 26+ forbids loops in config files and top-level loop statements in
+// scripts, so these are derived with collection expressions (param assignments,
+// which are permitted at the top level).
+params.databases.ensembl._any.run =
+  ['vertebrates', 'plants', 'fungi', 'protists', 'metazoa'].any { params.databases.ensembl[it]?.get('run', false) }
+params.needs_publications = params.databases.any { key, db -> willRun(key, db) }
+params.should_release     = params.databases.any { key, db -> willRun(key, db) && db.get('release', true) }
+params.needs_taxonomy     = params.databases.any { key, db -> willRun(key, db) && db.get('needs_taxonomy', false) }
 
 include { genes } from './genes'
 include { import_data } from './import-data'

--- a/main.nf
+++ b/main.nf
@@ -10,7 +10,7 @@ params.connections = new groovy.json.JsonSlurper().parse(new File(params.connect
 // runs if any of its divisions do.
 def willRun(key, db) {
   if (key == 'ensembl') {
-    return ['vertebrates', 'plants', 'fungi', 'protists', 'metazoa'].any { db[it]?.get('run', false) }
+    return ['vertebrates', 'plants', 'fungi', 'protists', 'metazoa'].any { d -> db[d]?.get('run', false) }
   }
   return db.get('run', false)
 }
@@ -21,7 +21,7 @@ def willRun(key, db) {
 // scripts, so these are derived with collection expressions (param assignments,
 // which are permitted at the top level).
 params.databases.ensembl._any.run =
-  ['vertebrates', 'plants', 'fungi', 'protists', 'metazoa'].any { params.databases.ensembl[it]?.get('run', false) }
+  ['vertebrates', 'plants', 'fungi', 'protists', 'metazoa'].any { d -> params.databases.ensembl[d]?.get('run', false) }
 params.needs_publications = params.databases.any { key, db -> willRun(key, db) }
 params.should_release     = params.databases.any { key, db -> willRun(key, db) && db.get('release', true) }
 params.needs_taxonomy     = params.databases.any { key, db -> willRun(key, db) && db.get('needs_taxonomy', false) }

--- a/main.nf
+++ b/main.nf
@@ -33,7 +33,7 @@ include { analyze } from './analyze'
 include { export } from './export'
 
 workflow {
-  Channel.of('ready') \
+  channel.of('ready') \
   | import_data \
   | ifEmpty('no import') \
   | analyze \

--- a/nextflow.config
+++ b/nextflow.config
@@ -1,6 +1,7 @@
 manifest {
   mainScript = 'main.nf'
   description = 'Import all RNAcentral data'
+  nextflowVersion = '>=26.04.0'
 }
 
 report {

--- a/nextflow.config
+++ b/nextflow.config
@@ -26,44 +26,12 @@ includeConfig "local.config"
 // Defaults in block form (not raw `params.x =` assignments) so that values
 // passed on the CLI (e.g. --needs_taxonomy true) actually take effect. Raw
 // assignments execute at config-load time and silently clobber CLI params.
-// The inference loop below only ever sets these to `true`, so it still layers
-// on top of a CLI override without fighting it.
+// The needs_publications / should_release / needs_taxonomy flags are inferred
+// from params.databases in main.nf (Nextflow 26 forbids loops in config), and
+// that inference only ever layers `true` on top of these defaults.
 params {
   should_release = false
   needs_publications = false
   skip_publications = false
   needs_taxonomy = false
-}
-
-params.databases.ensembl._any.run = false
-
-// Infer the needs_publications and should_release parameters. These are
-// basically flags to see if we need to download publications and if we need to
-// run the database release logic
-for (item in params.databases) {
-  def db = item.value;
-  def will_run = db.get('run', false);
-  if (item.key == 'ensembl') {
-    def ensembl_will_run = ['vertebrates', 'plants', 'fungi', 'protists', 'metazoa'].any {
-      db[it].get('run', false)
-    }
-    will_run = ensembl_will_run
-    if (ensembl_will_run) {
-      params.databases.ensembl._any.run = ensembl_will_run
-    }
-  }
-
-  if (will_run) {
-    params.needs_publications = true;
-    if (db.get('release', true)) {
-      params.should_release = true;
-    }
-    if (db.get('needs_taxonomy', false)) {
-      params.needs_taxonomy = true
-    }
-  }
-}
-
-if (params.skip_publications) {
-  params.needs_publications = false
 }

--- a/precompute.nf
+++ b/precompute.nf
@@ -151,24 +151,24 @@ workflow precompute {
   take: _flag
   main:
 
-    Channel.of("Starting precompute pipeline") | slack_message
+    channel.of("Starting precompute pipeline") | slack_message
 
-    Channel.fromPath('files/precompute/get-accessions/query.sql') | set { accession_query }
-    Channel.fromPath('files/precompute/load.ctl') | set { data_ctl }
-    Channel.fromPath('files/precompute/qa.ctl') | set { qa_ctl }
-    Channel.fromPath('files/precompute/post-load.sql') | set { post_load }
+    channel.fromPath('files/precompute/get-accessions/query.sql') | set { accession_query }
+    channel.fromPath('files/precompute/load.ctl') | set { data_ctl }
+    channel.fromPath('files/precompute/qa.ctl') | set { qa_ctl }
+    channel.fromPath('files/precompute/post-load.sql') | set { post_load }
 
-    Channel.fromPath('files/precompute/queries/basic.sql') | set { basic_sql }
-    Channel.fromPath('files/precompute/queries/coordinates.sql') | set { coordinate_sql }
-    Channel.fromPath('files/precompute/queries/rfam-hits.sql') | set { rfam_sql }
-    Channel.fromPath('files/precompute/queries/r2dt-hits.sql') | set { r2dt_sql }
-    Channel.fromPath('files/precompute/queries/previous.sql') | set { prev_sql }
-    Channel.fromPath('files/precompute/queries/orfs.sql') | set { orf_sql }
-    Channel.fromPath('files/precompute/queries/stopfree.sql') | set { stopfree_sql }
-    Channel.fromPath('files/precompute/queries/tcode.sql') | set { tcode_sql }
+    channel.fromPath('files/precompute/queries/basic.sql') | set { basic_sql }
+    channel.fromPath('files/precompute/queries/coordinates.sql') | set { coordinate_sql }
+    channel.fromPath('files/precompute/queries/rfam-hits.sql') | set { rfam_sql }
+    channel.fromPath('files/precompute/queries/r2dt-hits.sql') | set { r2dt_sql }
+    channel.fromPath('files/precompute/queries/previous.sql') | set { prev_sql }
+    channel.fromPath('files/precompute/queries/orfs.sql') | set { orf_sql }
+    channel.fromPath('files/precompute/queries/stopfree.sql') | set { stopfree_sql }
+    channel.fromPath('files/precompute/queries/tcode.sql') | set { tcode_sql }
 
     // repeats | build_precompute_context | set { context }
-    Channel.of(params.precompute.method) | build_urs_table | set { urs_counts }
+    channel.of(params.precompute.method) | build_urs_table | set { urs_counts }
     urs_counts | build_precompute_accessions | set { accessions_ready }
 
     build_metadata(
@@ -210,7 +210,7 @@ workflow precompute {
 }
 
 workflow {
-  precompute(Channel.of(true))
+  precompute(channel.of(true))
 
   workflow.onComplete {
     try {

--- a/precompute.nf
+++ b/precompute.nf
@@ -112,7 +112,7 @@ process query_accession_range {
 process process_range {
   tag { "$min-$max" }
   memory params.precompute.range.memory
-  containerOptions "--contain --workdir $baseDir/work/tmp --bind $baseDir"
+  containerOptions "--contain --workdir $projectDir/work/tmp --bind $projectDir"
 
   input:
   tuple val(min), val(max), path(accessions), path(metadata)

--- a/precompute.nf
+++ b/precompute.nf
@@ -218,7 +218,7 @@ workflow {
         slack_closure("Precompute workflow completed. Data import complete")
       }
     } catch (Exception e) {
-      log.warn "Could not send Slack notification: ${e.message}"
+      log.warn "Could not send Slack notification: ${e}"
     }
   }
 
@@ -226,7 +226,7 @@ workflow {
     try {
       slack_closure("Precompute workflow encountered an error and crashed")
     } catch (Exception e) {
-      log.warn "Could not send Slack notification: ${e.message}"
+      log.warn "Could not send Slack notification: ${e}"
     }
   }
 }

--- a/precompute.nf
+++ b/precompute.nf
@@ -210,23 +210,22 @@ workflow precompute {
 }
 
 workflow {
-  precompute(channel.of(true))
+  main:
+    precompute(channel.of(true))
 
-  workflow.onComplete {
+  onComplete:
     try {
-      if (workflow?.success) {
+      if (workflow.success) {
         slack_closure("Precompute workflow completed. Data import complete")
       }
     } catch (Exception e) {
       log.warn "Could not send Slack notification: ${e}"
     }
-  }
 
-  workflow.onError {
+  onError:
     try {
       slack_closure("Precompute workflow encountered an error and crashed")
     } catch (Exception e) {
       log.warn "Could not send Slack notification: ${e}"
     }
-  }
 }

--- a/precompute.nf
+++ b/precompute.nf
@@ -112,7 +112,7 @@ process query_accession_range {
 process process_range {
   tag { "$min-$max" }
   memory params.precompute.range.memory
-  containerOptions "--contain --workdir $projectDir/work/tmp --bind $projectDir"
+  containerOptions "--contain --workdir $baseDir/work/tmp --bind $baseDir"
 
   input:
   tuple val(min), val(max), path(accessions), path(metadata)

--- a/prepare-environment.nf
+++ b/prepare-environment.nf
@@ -38,14 +38,14 @@ workflow prepare_environment {
 }
 
 workflow {
-  channel.of("Starting...") | slack_message
-  prepare_environment()
+  main:
+    channel.of("Starting...") | slack_message
+    prepare_environment()
 
-  workflow.onComplete {
+  onComplete:
     try {
       slack_closure("Environment preparation completed")
     } catch (Exception e) {
       log.warn "Could not send Slack notification: ${e}"
     }
-  }
 }

--- a/prepare-environment.nf
+++ b/prepare-environment.nf
@@ -45,7 +45,7 @@ workflow {
     try {
       slack_closure("Environment preparation completed")
     } catch (Exception e) {
-      log.warn "Could not send Slack notification: ${e.message}"
+      log.warn "Could not send Slack notification: ${e}"
     }
   }
 }

--- a/prepare-environment.nf
+++ b/prepare-environment.nf
@@ -32,13 +32,13 @@ process get_r2dt_data {
 
 workflow prepare_environment {
   main:
-    Channel.of("Starting environment preparation") | slack_message
+    channel.of("Starting environment preparation") | slack_message
 
-    Channel.of("$params.r2dt.cms_path/../")| get_r2dt_data
+    channel.of("$params.r2dt.cms_path/../")| get_r2dt_data
 }
 
 workflow {
-  Channel.of("Starting...") | slack_message
+  channel.of("Starting...") | slack_message
   prepare_environment()
 
   workflow.onComplete {

--- a/r2dt-scan.nf
+++ b/r2dt-scan.nf
@@ -195,16 +195,16 @@ process load_models {
 
 
 workflow {
-  rfam_models = Channel.of("$baseDir/singularity/bind/r2dt/data/cms/rfam/all.cm")
-  crw_models = Channel.of("$baseDir/singularity/bind/r2dt/data/cms/crw/all.cm")
-  crw_metadata = Channel.of("https://raw.githubusercontent.com/RNAcentral/R2DT/v1.3/data/crw-metadata.tsv")
-  gtrnadb_models = Channel.fromPath("$baseDir/singularity/bind/r2dt/data/cms/gtrnadb/*.cm")
-  ribovision_lsu_metadata_url = Channel.of("https://raw.githubusercontent.com/RNAcentral/R2DT/v1.3/data/ribovision-lsu/metadata.tsv")
-  ribovision_ssu_metadata_url = Channel.of("https://raw.githubusercontent.com/RNAcentral/R2DT/v1.3/data/ribovision-ssu/metadata.tsv")
+  rfam_models = channel.of("$baseDir/singularity/bind/r2dt/data/cms/rfam/all.cm")
+  crw_models = channel.of("$baseDir/singularity/bind/r2dt/data/cms/crw/all.cm")
+  crw_metadata = channel.of("https://raw.githubusercontent.com/RNAcentral/R2DT/v1.3/data/crw-metadata.tsv")
+  gtrnadb_models = channel.fromPath("$baseDir/singularity/bind/r2dt/data/cms/gtrnadb/*.cm")
+  ribovision_lsu_metadata_url = channel.of("https://raw.githubusercontent.com/RNAcentral/R2DT/v1.3/data/ribovision-lsu/metadata.tsv")
+  ribovision_ssu_metadata_url = channel.of("https://raw.githubusercontent.com/RNAcentral/R2DT/v1.3/data/ribovision-ssu/metadata.tsv")
 
-  rnasep_metadata_url = Channel.of("https://raw.githubusercontent.com/RNAcentral/R2DT/v1.3/data/rnasep/metadata.tsv")
+  rnasep_metadata_url = channel.of("https://raw.githubusercontent.com/RNAcentral/R2DT/v1.3/data/rnasep/metadata.tsv")
 
-  load_ctl = Channel.of("$baseDir/files/r2dt/load-models.ctl")
+  load_ctl = channel.of("$baseDir/files/r2dt/load-models.ctl")
 
   rfam_models | extract_rfam_metadata | set { rfam_basepairs }
   rfam_models.combine(rfam_basepairs) | parse_rfam_models | set { rfam_data }

--- a/r2dt-scan.nf
+++ b/r2dt-scan.nf
@@ -14,10 +14,10 @@ process extract_gtrnadb_metadata {
     path("basepairs.csv")
 
 
-  shell:
-  '''
-  cmstat !{model_path} | awk ' /^[^#]/ { sep=","; printf "%s%s%s\\n", $2,sep,$8 }' | sed 's/euk/E/;s/arch/A/;s/bact/B/'  > basepairs.csv
-  '''
+  script:
+  """
+  cmstat $model_path | awk ' /^[^#]/ { sep=","; printf "%s%s%s\\n", \$2,sep,\$8 }' | sed 's/euk/E/;s/arch/A/;s/bact/B/'  > basepairs.csv
+  """
 }
 
 process parse_gtrnadb_model {
@@ -28,12 +28,12 @@ process parse_gtrnadb_model {
   output:
     path("model_data.csv")
 
-  shell:
-    '''
-    sort -k 1 !{basepairs} > basepairs_sorted.csv
-    rnac r2dt model-info gtrnadb !{model_path} model_data_nbp.csv
+  script:
+    """
+    sort -k 1 $basepairs > basepairs_sorted.csv
+    rnac r2dt model-info gtrnadb $model_path model_data_nbp.csv
     join -t","  model_data_nbp.csv basepairs_sorted.csv -o 1.1,1.2,1.3,1.4,1.5,1.6,1.7,2.2 > model_data.csv
-    '''
+    """
 }
 
 process extract_ribovision_metadata {
@@ -44,12 +44,12 @@ process extract_ribovision_metadata {
     output:
       path('length_basepair.csv')
 
-    shell:
-    '''
-      cmstat /rna/r2dt/data/ribovision-lsu/cms/all.cm | awk '/^[^#]/ {sep=","; printf "%s%s%s%s%s\\n",$2,sep,$6,sep,$8}' > basepair_length_lsu
-      cmstat /rna/r2dt/data/ribovision-ssu/cms/all.cm | awk '/^[^#]/ {sep=","; printf "%s%s%s%s%s\\n",$2,sep,$6,sep,$8}' > basepair_length_ssu
+    script:
+    """
+      cmstat /rna/r2dt/data/ribovision-lsu/cms/all.cm | awk '/^[^#]/ {sep=","; printf "%s%s%s%s%s\\n",\$2,sep,\$6,sep,\$8}' > basepair_length_lsu
+      cmstat /rna/r2dt/data/ribovision-ssu/cms/all.cm | awk '/^[^#]/ {sep=","; printf "%s%s%s%s%s\\n",\$2,sep,\$6,sep,\$8}' > basepair_length_ssu
       cat basepair_length_lsu basepair_length_ssu  | sort -k 1 > length_basepair.csv
-  '''
+  """
 }
 
 process parse_ribovision_models {
@@ -63,13 +63,13 @@ process parse_ribovision_models {
   output:
     path("model_data.csv")
 
-  shell:
-  '''
-  wget !{ribovision_metadata_url}
+  script:
+  """
+  wget $ribovision_metadata_url
   rnac r2dt model-info ribovision metadata.tsv model_data_us.csv
   sort -k 1 model_data_us.csv > model_data_s.csv
-  join -t","  model_data_s.csv !{length_basepair} -o 1.1,1.2,1.3,1.4,1.5,1.6,2.2,2.3 > model_data.csv
-  '''
+  join -t","  model_data_s.csv $length_basepair -o 1.1,1.2,1.3,1.4,1.5,1.6,2.2,2.3 > model_data.csv
+  """
 
 }
 
@@ -81,10 +81,10 @@ process extract_rnasep_metadata {
   output:
     path('length_basepair.csv')
 
-  shell:
-  '''
-  cmstat /rna/r2dt/data/rnasep/cms/all.cm | awk '/^[^#]/ {sep=","; printf "%s%s%s%s%s\\n",$2,sep,$6,sep,$8}' > length_basepair.csv
-  '''
+  script:
+  """
+  cmstat /rna/r2dt/data/rnasep/cms/all.cm | awk '/^[^#]/ {sep=","; printf "%s%s%s%s%s\\n",\$2,sep,\$6,sep,\$8}' > length_basepair.csv
+  """
 }
 
 process parse_rnasep_models {
@@ -96,14 +96,14 @@ process parse_rnasep_models {
   output:
     path("model_data.csv")
 
-  shell:
-  '''
-  wget !{rnasep_metadata_url}
+  script:
+  """
+  wget $rnasep_metadata_url
   sed -i 's/\\tNRC-1\\t/\\t/g' metadata.tsv
   rnac r2dt model-info rnase-p metadata.tsv model_data_us.csv
   sort -k1 model_data_us.csv > model_data_s.csv
-  join -t","  model_data_s.csv !{length_basepair} -o 1.1,1.2,1.3,1.4,1.5,1.6,2.2,2.3 > model_data.csv
-  '''
+  join -t","  model_data_s.csv $length_basepair -o 1.1,1.2,1.3,1.4,1.5,1.6,2.2,2.3 > model_data.csv
+  """
 
 }
 
@@ -118,10 +118,10 @@ process extract_rfam_metadata {
   output:
     path('basepairs.csv')
 
-  shell:
-  '''
-  cmstat !{all_models} | awk '/^[^#]/ {sep=","; printf "%s%s%s\\n",$3,sep,$8}' > basepairs.csv
-  '''
+  script:
+  """
+  cmstat $all_models | awk '/^[^#]/ {sep=","; printf "%s%s%s\\n",\$3,sep,\$8}' > basepairs.csv
+  """
 }
 
 process parse_rfam_models {
@@ -132,11 +132,11 @@ process parse_rfam_models {
   output:
     path("model_data.csv")
 
-  shell:
-  '''
-  rnac r2dt model-info rfam !{all_models} $PGDATABASE model_data_nbp.csv
-  join -t","  model_data_nbp.csv !{basepairs} -o 1.1,1.2,1.3,1.4,1.5,1.6,1.7,2.2 > model_data.csv
-  '''
+  script:
+  """
+  rnac r2dt model-info rfam $all_models \$PGDATABASE model_data_nbp.csv
+  join -t","  model_data_nbp.csv $basepairs -o 1.1,1.2,1.3,1.4,1.5,1.6,1.7,2.2 > model_data.csv
+  """
 }
 
 process extract_crw_metadata {
@@ -150,10 +150,10 @@ process extract_crw_metadata {
   output:
     path("basepairs.csv")
 
-  shell:
-  '''
-    cmstat !{all_models} | awk '/^[^#]/ {sep=","; printf "%s%s%s\\n",$2,sep,$8}' > basepairs.csv
-  '''
+  script:
+  """
+    cmstat $all_models | awk '/^[^#]/ {sep=","; printf "%s%s%s\\n",\$2,sep,\$8}' > basepairs.csv
+  """
 }
 
 process parse_crw_models {
@@ -193,18 +193,17 @@ process load_models {
 
 
 
-
 workflow {
-  rfam_models = channel.of("$baseDir/singularity/bind/r2dt/data/cms/rfam/all.cm")
-  crw_models = channel.of("$baseDir/singularity/bind/r2dt/data/cms/crw/all.cm")
+  rfam_models = channel.of("$projectDir/singularity/bind/r2dt/data/cms/rfam/all.cm")
+  crw_models = channel.of("$projectDir/singularity/bind/r2dt/data/cms/crw/all.cm")
   crw_metadata = channel.of("https://raw.githubusercontent.com/RNAcentral/R2DT/v1.3/data/crw-metadata.tsv")
-  gtrnadb_models = channel.fromPath("$baseDir/singularity/bind/r2dt/data/cms/gtrnadb/*.cm")
+  gtrnadb_models = channel.fromPath("$projectDir/singularity/bind/r2dt/data/cms/gtrnadb/*.cm")
   ribovision_lsu_metadata_url = channel.of("https://raw.githubusercontent.com/RNAcentral/R2DT/v1.3/data/ribovision-lsu/metadata.tsv")
   ribovision_ssu_metadata_url = channel.of("https://raw.githubusercontent.com/RNAcentral/R2DT/v1.3/data/ribovision-ssu/metadata.tsv")
 
   rnasep_metadata_url = channel.of("https://raw.githubusercontent.com/RNAcentral/R2DT/v1.3/data/rnasep/metadata.tsv")
 
-  load_ctl = channel.of("$baseDir/files/r2dt/load-models.ctl")
+  load_ctl = channel.of("$projectDir/files/r2dt/load-models.ctl")
 
   rfam_models | extract_rfam_metadata | set { rfam_basepairs }
   rfam_models.combine(rfam_basepairs) | parse_rfam_models | set { rfam_data }

--- a/r2dt-scan.nf
+++ b/r2dt-scan.nf
@@ -194,16 +194,16 @@ process load_models {
 
 
 workflow {
-  rfam_models = channel.of("$projectDir/singularity/bind/r2dt/data/cms/rfam/all.cm")
-  crw_models = channel.of("$projectDir/singularity/bind/r2dt/data/cms/crw/all.cm")
+  rfam_models = channel.of("$baseDir/singularity/bind/r2dt/data/cms/rfam/all.cm")
+  crw_models = channel.of("$baseDir/singularity/bind/r2dt/data/cms/crw/all.cm")
   crw_metadata = channel.of("https://raw.githubusercontent.com/RNAcentral/R2DT/v1.3/data/crw-metadata.tsv")
-  gtrnadb_models = channel.fromPath("$projectDir/singularity/bind/r2dt/data/cms/gtrnadb/*.cm")
+  gtrnadb_models = channel.fromPath("$baseDir/singularity/bind/r2dt/data/cms/gtrnadb/*.cm")
   ribovision_lsu_metadata_url = channel.of("https://raw.githubusercontent.com/RNAcentral/R2DT/v1.3/data/ribovision-lsu/metadata.tsv")
   ribovision_ssu_metadata_url = channel.of("https://raw.githubusercontent.com/RNAcentral/R2DT/v1.3/data/ribovision-ssu/metadata.tsv")
 
   rnasep_metadata_url = channel.of("https://raw.githubusercontent.com/RNAcentral/R2DT/v1.3/data/rnasep/metadata.tsv")
 
-  load_ctl = channel.of("$projectDir/files/r2dt/load-models.ctl")
+  load_ctl = channel.of("$baseDir/files/r2dt/load-models.ctl")
 
   rfam_models | extract_rfam_metadata | set { rfam_basepairs }
   rfam_models.combine(rfam_basepairs) | parse_rfam_models | set { rfam_data }

--- a/references-metadata-rnacentral.nf
+++ b/references-metadata-rnacentral.nf
@@ -33,6 +33,6 @@ process get_job {
 
 
 workflow {
-    Channel.fromPath('workflows/references/results/*.txt') | get_urs
-    Channel.fromPath('workflows/references/results/*.txt') | get_job
+    channel.fromPath('workflows/references/results/*.txt') | get_urs
+    channel.fromPath('workflows/references/results/*.txt') | get_job
 }

--- a/references-metadata-rnacentral.nf
+++ b/references-metadata-rnacentral.nf
@@ -1,7 +1,7 @@
 nextflow.enable.dsl=2
 
 process get_urs {
-    publishDir "$baseDir/workflows/references/metadata/rnacentral", mode: 'copy'
+    publishDir "$projectDir/workflows/references/metadata/rnacentral", mode: 'copy'
 
     input:
     path(database)
@@ -16,7 +16,7 @@ process get_urs {
 }
 
 process get_job {
-    publishDir "$baseDir/workflows/references/metadata/rnacentral", mode: 'copy'
+    publishDir "$projectDir/workflows/references/metadata/rnacentral", mode: 'copy'
 
     input:
     path(database)

--- a/references-metadata-rnacentral.nf
+++ b/references-metadata-rnacentral.nf
@@ -1,7 +1,7 @@
 nextflow.enable.dsl=2
 
 process get_urs {
-    publishDir "$projectDir/workflows/references/metadata/rnacentral", mode: 'copy'
+    publishDir "$baseDir/workflows/references/metadata/rnacentral", mode: 'copy'
 
     input:
     path(database)
@@ -16,7 +16,7 @@ process get_urs {
 }
 
 process get_job {
-    publishDir "$projectDir/workflows/references/metadata/rnacentral", mode: 'copy'
+    publishDir "$baseDir/workflows/references/metadata/rnacentral", mode: 'copy'
 
     input:
     path(database)

--- a/report.nf
+++ b/report.nf
@@ -1,6 +1,7 @@
 process send_completion_report {
   executor 'local'
 
+  script:
   """
   rnac notify report
   """

--- a/select_databases.nf
+++ b/select_databases.nf
@@ -6,8 +6,5 @@ include { select } from './workflows/databases/select.nf'
 
 
 workflow {
-  emit: done
-
-  select() | set { done }
-
+  select()
 }

--- a/weekly-update/update.config
+++ b/weekly-update/update.config
@@ -48,7 +48,7 @@ params {
 
 singularity {
   enabled = true
-  cacheDir = "$projectDir/singularity"
+  cacheDir = "$baseDir/singularity"
 }
 
 notification {

--- a/weekly-update/update.config
+++ b/weekly-update/update.config
@@ -48,7 +48,7 @@ params {
 
 singularity {
   enabled = true
-  cacheDir = "$baseDir/singularity"
+  cacheDir = "$projectDir/singularity"
 }
 
 notification {

--- a/workflows/cpat.nf
+++ b/workflows/cpat.nf
@@ -122,7 +122,7 @@ workflow cpat {
     parse_results.out.orfs | collect | set { orfs }
 
     store_results(data, orfs, load_ctl, orf_ctl)
-    data | map { _v -> 'cpat done' } | first | set { done }
+    data | map { _v -> 'cpat done' } | set { done }
     }
   emit: done
 }

--- a/workflows/cpat.nf
+++ b/workflows/cpat.nf
@@ -122,7 +122,7 @@ workflow cpat {
     parse_results.out.orfs | collect | set { orfs }
 
     store_results(data, orfs, load_ctl, orf_ctl)
-    data | map { _ -> 'cpat done' } | first | set { done }
+    data | map { _v -> 'cpat done' } | first | set { done }
     }
   emit: done
 }

--- a/workflows/cpat.nf
+++ b/workflows/cpat.nf
@@ -11,7 +11,7 @@ process find_models {
   path('CPAT-3.0.4/dat/*_Hexamer.tsv'), emit: hexamers
   path('cutoffs.csv'), emit: cutoffs
 
-  when: { params.cpat?.run }
+  when: params.cpat?.run
 
   script:
   """

--- a/workflows/cpat.nf
+++ b/workflows/cpat.nf
@@ -3,8 +3,6 @@
 nextflow.enable.dsl=2
 
 process find_models {
-  when: { params.cpat?.run }
-
   input:
   val(_flag)
 
@@ -12,6 +10,8 @@ process find_models {
   path('CPAT-3.0.4/dat/*_logitModel.RData'), emit: rdata
   path('CPAT-3.0.4/dat/*_Hexamer.tsv'), emit: hexamers
   path('cutoffs.csv'), emit: cutoffs
+
+  when: { params.cpat?.run }
 
   script:
   """

--- a/workflows/cpat.nf
+++ b/workflows/cpat.nf
@@ -112,7 +112,7 @@ workflow cpat {
     | map { model_name, rd, hexamer -> [model_name, rd, hexamer, params.cpat.taxid_mapping[model_name]] } \
     | combine(query) \
     | find_sequences \
-    | flatMap { model_name, rd, hexamer, seqs -> (seqs instanceof ArrayList) ? seqs.collect { [model_name, rd, hexamer, it] } : [[model_name, rd, hexamer, seqs]] } \
+    | flatMap { model_name, rd, hexamer, seqs -> (seqs instanceof ArrayList) ? seqs.collect { s -> [model_name, rd, hexamer, s] } : [[model_name, rd, hexamer, seqs]] } \
     | cpat_scan \
     | filter { _model, f -> f.exists() } \
     | combine(find_models.out.cutoffs) \

--- a/workflows/cpat.nf
+++ b/workflows/cpat.nf
@@ -88,12 +88,12 @@ workflow cpat {
   take: flag
   main:
     if (!params.cpat.run) {
-      Channel.of('cpat skipped') | set { done }
+      channel.of('cpat skipped') | set { done }
     } else {
 
-    Channel.fromPath('files/cpat/results.ctl') | set { load_ctl }
-    Channel.fromPath('files/cpat/orfs.ctl') | set { orf_ctl }
-    Channel.fromPath('files/cpat/query.sql') | set { query }
+    channel.fromPath('files/cpat/results.ctl') | set { load_ctl }
+    channel.fromPath('files/cpat/orfs.ctl') | set { orf_ctl }
+    channel.fromPath('files/cpat/query.sql') | set { query }
 
     flag | find_models
 
@@ -128,5 +128,5 @@ workflow cpat {
 }
 
 workflow {
-  cpat(Channel.of('ready'))
+  cpat(channel.of('ready'))
 }

--- a/workflows/databases/5srrnadb.nf
+++ b/workflows/databases/5srrnadb.nf
@@ -2,7 +2,7 @@ process five_s_rrnadb {
   output:
   path('*.csv')
 
-  when: { params.databases["5srrnadb"]?.run }
+  when: params.databases["5srrnadb"]?.run
 
   script:
   """

--- a/workflows/databases/5srrnadb.nf
+++ b/workflows/databases/5srrnadb.nf
@@ -1,8 +1,8 @@
 process five_s_rrnadb {
-  when: { params.databases["5srrnadb"]?.run }
-
   output:
   path('*.csv')
+
+  when: { params.databases["5srrnadb"]?.run }
 
   script:
   """

--- a/workflows/databases/circatlas.nf
+++ b/workflows/databases/circatlas.nf
@@ -5,7 +5,7 @@ process fetch {
   output:
   path('circatlas.json')
 
-  when: { params.databases.circatlas?.run }
+  when: params.databases.circatlas?.run
 
   script:
   """
@@ -22,7 +22,7 @@ process parse {
   output:
   path('*.csv')
 
-  when: { params.databases.circatlas?.run }
+  when: params.databases.circatlas?.run
 
   script:
   """

--- a/workflows/databases/circatlas.nf
+++ b/workflows/databases/circatlas.nf
@@ -31,7 +31,7 @@ process parse {
 }
 
 workflow circatlas {
-  emit: data
   main:
   fetch | parse | set { data }
+  emit: data
 }

--- a/workflows/databases/circpedia.nf
+++ b/workflows/databases/circpedia.nf
@@ -9,7 +9,7 @@ process fetch_annotation {
   output:
   tuple val(species), path("${species.annotation}.txt")
 
-  when: { params.databases.circpedia?.run }
+  when: params.databases.circpedia?.run
 
   script:
   """
@@ -31,7 +31,7 @@ process fetch_fasta {
   output:
   tuple val(species), path(annotation_file), path("${species.fasta}.fa")
 
-  when: { params.databases.circpedia?.run }
+  when: params.databases.circpedia?.run
 
   script:
   """

--- a/workflows/databases/circpedia.nf
+++ b/workflows/databases/circpedia.nf
@@ -64,7 +64,7 @@ process parse_data {
 
 workflow circpedia {
   main:
-    Channel.fromList(params.databases.circpedia.species)
+    channel.fromList(params.databases.circpedia.species)
     | fetch_annotation
     | fetch_fasta
     | parse_data

--- a/workflows/databases/circpedia.nf
+++ b/workflows/databases/circpedia.nf
@@ -63,12 +63,12 @@ process parse_data {
 }
 
 workflow circpedia {
-  emit: data
-
   main:
     Channel.fromList(params.databases.circpedia.species)
     | fetch_annotation
     | fetch_fasta
     | parse_data
     | set { data }
+
+  emit: data
 }

--- a/workflows/databases/crw.nf
+++ b/workflows/databases/crw.nf
@@ -17,9 +17,9 @@ process fetch_and_process {
 }
 
 workflow crw {
-  emit: data
   main:
     Channel.fromPath('files/import-data/crw/metadata.sql') \
     | fetch_and_process \
     | set { data }
+  emit: data
 }

--- a/workflows/databases/crw.nf
+++ b/workflows/databases/crw.nf
@@ -5,7 +5,7 @@ process fetch_and_process {
   output:
   path('*.csv')
 
-  when: { params.databases.crw?.run }
+  when: params.databases.crw?.run
 
   script:
   """

--- a/workflows/databases/crw.nf
+++ b/workflows/databases/crw.nf
@@ -18,7 +18,7 @@ process fetch_and_process {
 
 workflow crw {
   main:
-    Channel.fromPath('files/import-data/crw/metadata.sql') \
+    channel.fromPath('files/import-data/crw/metadata.sql') \
     | fetch_and_process \
     | set { data }
   emit: data

--- a/workflows/databases/ena.nf
+++ b/workflows/databases/ena.nf
@@ -10,7 +10,7 @@ process list_subdirs {
   output:
   tuple val(name), path("${name}-dirs.txt")
 
-  when: { params.databases.ena.run }
+  when: params.databases.ena.run
 
   script:
   """
@@ -30,7 +30,7 @@ process fetch_directory {
   output:
   path("${name}-chunks/*.ncr"), optional: true
 
-  when: { params.databases.ena?.run }
+  when: params.databases.ena?.run
 
   script:
   """
@@ -67,7 +67,7 @@ process fetch_metadata {
   output:
   tuple path('tpa.tsv'), path('model-lengths.csv')
 
-  when: { params.databases.ena?.run }
+  when: params.databases.ena?.run
 
   script:
   """

--- a/workflows/databases/ena.nf
+++ b/workflows/databases/ena.nf
@@ -97,8 +97,8 @@ process process_file {
   fi
   rnac ena parse --counts $raw-counts.txt $raw $tpa ribotyper-results $model_lengths .
 
-  mkdir $projectDir/ena-counts 2>/dev/null || true
-  cp $raw-counts.txt $projectDir/ena-counts/
+  mkdir $baseDir/ena-counts 2>/dev/null || true
+  cp $raw-counts.txt $baseDir/ena-counts/
   """
 }
 

--- a/workflows/databases/ena.nf
+++ b/workflows/databases/ena.nf
@@ -1,6 +1,5 @@
 process list_subdirs {
   tag { "$name" }
-  when { params.databases.ena.run }
   queue 'datamover'
   containerOptions "${params.common_container} --bind /nfs:/nfs"
   time '1h'
@@ -11,6 +10,9 @@ process list_subdirs {
   output:
   tuple val(name), path("${name}-dirs.txt")
 
+  when: { params.databases.ena.run }
+
+  script:
   """
   find -L ${path} -mindepth 1 -maxdepth 1 -type d > ${name}-dirs.txt
   """
@@ -101,7 +103,6 @@ process process_file {
 }
 
 workflow ena {
-  emit: data
   main:
     Channel.fromPath('files/import-data/ena/tpa-urls.txt') | set { urls }
     fetch_metadata(urls) | set { metadata }
@@ -130,4 +131,6 @@ workflow ena {
     | combine(metadata) \
     | process_file \
     | set { data }
+
+  emit: data
 }

--- a/workflows/databases/ena.nf
+++ b/workflows/databases/ena.nf
@@ -104,10 +104,10 @@ process process_file {
 
 workflow ena {
   main:
-    Channel.fromPath('files/import-data/ena/tpa-urls.txt') | set { urls }
+    channel.fromPath('files/import-data/ena/tpa-urls.txt') | set { urls }
     fetch_metadata(urls) | set { metadata }
 
-    Channel.fromList([
+    channel.fromList([
       ['wgs', "$params.databases.ena.remote/wgs/"],
       ['tls', "$params.databases.ena.remote/tls/"],
       ['tsa', "$params.databases.ena.remote/tsa/"],
@@ -121,7 +121,7 @@ workflow ena {
       } \
     | set { subdir_batches }
 
-    Channel.fromList([
+    channel.fromList([
       ['con', ["$params.databases.ena.remote/con/"]],
       ['std', ["$params.databases.ena.remote/std/"]],
     ]) \

--- a/workflows/databases/ena.nf
+++ b/workflows/databases/ena.nf
@@ -115,9 +115,9 @@ workflow ena {
     | list_subdirs \
     | flatMap { name, listing ->
         listing.readLines()
-          .findAll { it.trim() }
+          .findAll { line -> line.trim() }
           .collate( params.databases.ena.subdir_batch_size )
-          .collect { batch -> [name, batch.collect { it.trim() }] }
+          .collect { batch -> [name, batch.collect { s -> s.trim() }] }
       } \
     | set { subdir_batches }
 

--- a/workflows/databases/ena.nf
+++ b/workflows/databases/ena.nf
@@ -97,8 +97,8 @@ process process_file {
   fi
   rnac ena parse --counts $raw-counts.txt $raw $tpa ribotyper-results $model_lengths .
 
-  mkdir $baseDir/ena-counts 2>/dev/null || true
-  cp $raw-counts.txt $baseDir/ena-counts/
+  mkdir $projectDir/ena-counts 2>/dev/null || true
+  cp $raw-counts.txt $projectDir/ena-counts/
   """
 }
 

--- a/workflows/databases/ensembl.nf
+++ b/workflows/databases/ensembl.nf
@@ -99,12 +99,12 @@ workflow ensembl {
     | filter { division -> params.databases.ensembl[division]?.run } \
     | find_urls \
     | splitCsv \
-    | filter { division, species, dat_url, gff_url ->
+    | filter { division, species, _dat_url, _gff_url ->
       !params.databases.ensembl[division].exclude.any { p -> species.toLowerCase() =~ p }
     } \
     | fetch_species_data \
     | flatMap { division, dat_files, gff_file ->
-      (dat_files instanceof ArrayList) ? dat_files.collect { [division, it, gff_file] } : [[division, dat_files, gff_file]]
+      (dat_files instanceof ArrayList) ? dat_files.collect { f -> [division, f, gff_file] } : [[division, dat_files, gff_file]]
     } \
     | combine(fetch_metadata(rfam)) \
     | parse_data \

--- a/workflows/databases/ensembl.nf
+++ b/workflows/databases/ensembl.nf
@@ -87,9 +87,9 @@ process parse_data {
 
 workflow ensembl {
   main:
-    Channel.fromPath('files/import-data/rfam/families.sql') | set { rfam }
+    channel.fromPath('files/import-data/rfam/families.sql') | set { rfam }
 
-    Channel.fromList([
+    channel.fromList([
       'plants',
       'fungi',
       'protists',

--- a/workflows/databases/ensembl.nf
+++ b/workflows/databases/ensembl.nf
@@ -86,7 +86,6 @@ process parse_data {
 }
 
 workflow ensembl {
-  emit: data
   main:
     Channel.fromPath('files/import-data/rfam/families.sql') | set { rfam }
 
@@ -110,4 +109,6 @@ workflow ensembl {
     | combine(fetch_metadata(rfam)) \
     | parse_data \
     | set { data }
+
+  emit: data
 }

--- a/workflows/databases/ensembl.nf
+++ b/workflows/databases/ensembl.nf
@@ -5,7 +5,7 @@ process fetch_metadata {
   output:
   path('families.tsv')
 
-  when: { params.databases.ensembl?._any?.run }
+  when: params.databases.ensembl?._any?.run
 
   script:
   """
@@ -26,7 +26,7 @@ process find_urls {
   output:
   path('species.txt')
 
-  when: { params.databases.ensembl[division]?.run }
+  when: params.databases.ensembl[division]?.run
 
   script:
     """

--- a/workflows/databases/evlncrnas.nf
+++ b/workflows/databases/evlncrnas.nf
@@ -2,7 +2,7 @@ process fetch {
   output:
   path('EVLncRNAs3_alldata')
 
-  when: { params.databases.evlncrnas?.run }
+  when: params.databases.evlncrnas?.run
 
   script:
   """
@@ -21,7 +21,7 @@ process rnc_dump {
   output:
   path('*.csv')
 
-  when: { params.databases.evlncrnas?.run }
+  when: params.databases.evlncrnas?.run
 
   script:
   """

--- a/workflows/databases/evlncrnas.nf
+++ b/workflows/databases/evlncrnas.nf
@@ -47,11 +47,11 @@ process parse {
 
 
 workflow evlncrnas {
-  emit: data
   main:
   Channel.fromPath('files/import-data/evlncrnas/dump-lookup.sql') | set { dump_sql }
     fetch | set {ev_data}
     dump_sql | rnc_dump | set {rnc_data}
 
     ev_data.combine(rnc_data) | parse | set {data}
+  emit: data
 }

--- a/workflows/databases/evlncrnas.nf
+++ b/workflows/databases/evlncrnas.nf
@@ -48,7 +48,7 @@ process parse {
 
 workflow evlncrnas {
   main:
-  Channel.fromPath('files/import-data/evlncrnas/dump-lookup.sql') | set { dump_sql }
+  channel.fromPath('files/import-data/evlncrnas/dump-lookup.sql') | set { dump_sql }
     fetch | set {ev_data}
     dump_sql | rnc_dump | set {rnc_data}
 

--- a/workflows/databases/expressionatlas.nf
+++ b/workflows/databases/expressionatlas.nf
@@ -113,7 +113,6 @@ process group_and_convert {
 
 workflow expressionatlas {
 
-  emit: data
   main:
 
   if( params.databases.expressionatlas?.run ) {
@@ -143,6 +142,7 @@ workflow expressionatlas {
     Channel.empty() | set { data }
   }
 
+  emit: data
 }
 
 

--- a/workflows/databases/expressionatlas.nf
+++ b/workflows/databases/expressionatlas.nf
@@ -116,9 +116,9 @@ workflow expressionatlas {
   main:
 
   if( params.databases.expressionatlas?.run ) {
-    Channel.fromPath('files/import-data/expressionatlas/lookup-dump-query.sql') | set { lookup_sql }
-    Channel.of(params.databases.expressionatlas.remote) | set { tsv_path }
-    Channel.of(params.databases.expressionatlas.cache) | set { ea_cache }
+    channel.fromPath('files/import-data/expressionatlas/lookup-dump-query.sql') | set { lookup_sql }
+    channel.of(params.databases.expressionatlas.remote) | set { tsv_path }
+    channel.of(params.databases.expressionatlas.cache) | set { ea_cache }
 
     tsv_path.combine(ea_cache) | synchronize_cache |  set { cache_syncd }
 
@@ -139,7 +139,7 @@ workflow expressionatlas {
 
   }
   else {
-    Channel.empty() | set { data }
+    channel.empty() | set { data }
   }
 
   emit: data

--- a/workflows/databases/expressionatlas.nf
+++ b/workflows/databases/expressionatlas.nf
@@ -39,7 +39,7 @@ process synchronize_cache {
   output:
     val('cache synchronized')
 
-  when: { params.databases.expressionatlas?.run }
+  when: params.databases.expressionatlas?.run
 
   script:
   """

--- a/workflows/databases/flybase.nf
+++ b/workflows/databases/flybase.nf
@@ -2,7 +2,7 @@ process flybase {
   output:
   path('*.csv')
 
-  when: { params.databases.flybase?.run }
+  when: params.databases.flybase?.run
 
   script:
   """

--- a/workflows/databases/flybase.nf
+++ b/workflows/databases/flybase.nf
@@ -1,8 +1,8 @@
 process flybase {
-  when: { params.databases.flybase?.run }
-
   output:
   path('*.csv')
+
+  when: { params.databases.flybase?.run }
 
   script:
   """

--- a/workflows/databases/genecards_suite.nf
+++ b/workflows/databases/genecards_suite.nf
@@ -42,7 +42,7 @@ process process {
 
 workflow genecards_suite {
   main:
-    Channel.fromList([
+    channel.fromList([
       ['genecards', params.databases.genecards.remote, params.databases.genecards.column],
       ['malacards', params.databases.malacards.remote, params.databases.malacards.column],
     ]) \

--- a/workflows/databases/genecards_suite.nf
+++ b/workflows/databases/genecards_suite.nf
@@ -46,7 +46,7 @@ workflow genecards_suite {
       ['genecards', params.databases.genecards.remote, params.databases.genecards.column],
       ['malacards', params.databases.malacards.remote, params.databases.malacards.column],
     ]) \
-    | filter { name, r, c -> params.databases[name]?.run } \
+    | filter { name, _r, _c -> params.databases[name]?.run } \
     | fetch \
     | process \
     | set { data }

--- a/workflows/databases/genecards_suite.nf
+++ b/workflows/databases/genecards_suite.nf
@@ -9,7 +9,7 @@ process fetch {
   output:
   tuple val(name), path('data.tsv'), val(column_name)
 
-  when: { params.databases[name]?.run }
+  when: params.databases[name]?.run
 
   script:
   if (data.getExtension() == "gz")

--- a/workflows/databases/genecards_suite.nf
+++ b/workflows/databases/genecards_suite.nf
@@ -41,7 +41,6 @@ process process {
 }
 
 workflow genecards_suite {
-  emit: data
   main:
     Channel.fromList([
       ['genecards', params.databases.genecards.remote, params.databases.genecards.column],
@@ -51,4 +50,6 @@ workflow genecards_suite {
     | fetch \
     | process \
     | set { data }
+
+  emit: data
 }

--- a/workflows/databases/gtrnadb.nf
+++ b/workflows/databases/gtrnadb.nf
@@ -5,7 +5,7 @@ process fetch_data {
   output:
   path('*.json')
 
-  when: { params.databases.gtrnadb?.run }
+  when: params.databases.gtrnadb?.run
 
   script:
   """

--- a/workflows/databases/hgnc.nf
+++ b/workflows/databases/hgnc.nf
@@ -1,8 +1,8 @@
 process hgnc {
-  when: { params.databases.hgnc?.run }
-
   output:
   path('*.csv')
+
+  when: { params.databases.hgnc?.run }
 
   script:
   """

--- a/workflows/databases/hgnc.nf
+++ b/workflows/databases/hgnc.nf
@@ -2,7 +2,7 @@ process hgnc {
   output:
   path('*.csv')
 
-  when: { params.databases.hgnc?.run }
+  when: params.databases.hgnc?.run
 
   script:
   """

--- a/workflows/databases/intact.nf
+++ b/workflows/databases/intact.nf
@@ -2,7 +2,7 @@ process intact {
   output:
   path('*.csv')
 
-  when: { params.databases.intact?.run }
+  when: params.databases.intact?.run
 
   script:
   """

--- a/workflows/databases/japonicusdb.nf
+++ b/workflows/databases/japonicusdb.nf
@@ -1,8 +1,8 @@
 process japonicusdb {
-  when: { params.databases.japonicusdb?.run }
-
   output:
   path('*.csv')
+
+  when: { params.databases.japonicusdb?.run }
 
   script:
   """

--- a/workflows/databases/japonicusdb.nf
+++ b/workflows/databases/japonicusdb.nf
@@ -2,7 +2,7 @@ process japonicusdb {
   output:
   path('*.csv')
 
-  when: { params.databases.japonicusdb?.run }
+  when: params.databases.japonicusdb?.run
 
   script:
   """

--- a/workflows/databases/lncbase.nf
+++ b/workflows/databases/lncbase.nf
@@ -1,8 +1,8 @@
 process lncbase {
-  when: { params.databases.lncbase?.run }
-
   output:
   path('*.csv')
+
+  when: { params.databases.lncbase?.run }
 
   script:
   """

--- a/workflows/databases/lncbase.nf
+++ b/workflows/databases/lncbase.nf
@@ -2,7 +2,7 @@ process lncbase {
   output:
   path('*.csv')
 
-  when: { params.databases.lncbase?.run }
+  when: params.databases.lncbase?.run
 
   script:
   """

--- a/workflows/databases/lncbook.nf
+++ b/workflows/databases/lncbook.nf
@@ -2,7 +2,7 @@ process lncbook {
   output:
   path('*.csv')
 
-  when: { params.databases.lncbook?.run }
+  when: params.databases.lncbook?.run
 
   script:
   """

--- a/workflows/databases/lncbook.nf
+++ b/workflows/databases/lncbook.nf
@@ -1,8 +1,8 @@
 process lncbook {
-  when: { params.databases.lncbook?.run }
-
   output:
   path('*.csv')
+
+  when: { params.databases.lncbook?.run }
 
   script:
   """

--- a/workflows/databases/lncipedia.nf
+++ b/workflows/databases/lncipedia.nf
@@ -1,11 +1,11 @@
 process lncipedia {
   memory '5GB'
 
-  when:
-  params.databases.lncipedia?.run == true
-
   output:
   path('*.csv')
+
+  when:
+  params.databases.lncipedia?.run == true
 
   script:
   """

--- a/workflows/databases/lncipedia.nf
+++ b/workflows/databases/lncipedia.nf
@@ -4,8 +4,7 @@ process lncipedia {
   output:
   path('*.csv')
 
-  when:
-  params.databases.lncipedia?.run == true
+  when: params.databases.lncipedia?.run
 
   script:
   """

--- a/workflows/databases/mgnify.nf
+++ b/workflows/databases/mgnify.nf
@@ -28,7 +28,6 @@ process mgnify_parse {
 
 
 workflow mgnify {
-  emit: data
   main:
     if ( params.databases.mgnify?.run ) {
       mgnify_fetch | flatten | mgnify_parse | set { data }
@@ -36,4 +35,6 @@ workflow mgnify {
     else {
       Channel.empty() | set { data }
     }
+
+  emit: data
 }

--- a/workflows/databases/mgnify.nf
+++ b/workflows/databases/mgnify.nf
@@ -4,7 +4,7 @@ process mgnify_fetch {
   output:
     path('*.json')
 
-  when: { params.databases.mgnify?.run }
+  when: params.databases.mgnify?.run
 
   script:
   """

--- a/workflows/databases/mgnify.nf
+++ b/workflows/databases/mgnify.nf
@@ -33,7 +33,7 @@ workflow mgnify {
       mgnify_fetch | flatten | mgnify_parse | set { data }
     }
     else {
-      Channel.empty() | set { data }
+      channel.empty() | set { data }
     }
 
   emit: data

--- a/workflows/databases/mirbase.nf
+++ b/workflows/databases/mirbase.nf
@@ -2,7 +2,7 @@ process mirbase {
   output:
   path('*.csv')
 
-  when: { params.databases.mirbase?.run }
+  when: params.databases.mirbase?.run
 
   script:
   """

--- a/workflows/databases/mirgenedb.nf
+++ b/workflows/databases/mirgenedb.nf
@@ -5,7 +5,7 @@ process mirgenedb {
   output:
   path('*.csv')
 
-  when: { params.databases.mirgenedb?.run }
+  when: params.databases.mirgenedb?.run
 
   script:
   """

--- a/workflows/databases/mirtrondb.nf
+++ b/workflows/databases/mirtrondb.nf
@@ -29,7 +29,8 @@ process parse {
 }
 
 workflow mirtrondb {
-  emit: data
   main:
   fetch | parse | set { data }
+
+  emit: data
 }

--- a/workflows/databases/mirtrondb.nf
+++ b/workflows/databases/mirtrondb.nf
@@ -5,7 +5,7 @@ process fetch {
   output:
   path('all.tsv')
 
-  when: { params.databases.mirtrondb?.run }
+  when: params.databases.mirtrondb?.run
 
   script:
   """
@@ -20,7 +20,7 @@ process parse {
   output:
   path('*.csv')
 
-  when: { params.databases.mirtrondb?.run }
+  when: params.databases.mirtrondb?.run
 
   script:
   """

--- a/workflows/databases/modomics.nf
+++ b/workflows/databases/modomics.nf
@@ -5,7 +5,7 @@ process fetch {
   output:
   path('modomics.json')
 
-  when: { params.databases.modomics?.run }
+  when: params.databases.modomics?.run
 
   script:
   """
@@ -20,7 +20,7 @@ process parse {
   output:
   path('*.csv')
 
-  when: { params.databases.modomics?.run }
+  when: params.databases.modomics?.run
 
   script:
   """

--- a/workflows/databases/modomics.nf
+++ b/workflows/databases/modomics.nf
@@ -29,7 +29,8 @@ process parse {
 }
 
 workflow modomics {
-  emit: data
   main:
   fetch | parse | set { data }
+
+  emit: data
 }

--- a/workflows/databases/pdbe.nf
+++ b/workflows/databases/pdbe.nf
@@ -5,7 +5,7 @@ process pdbe {
   output:
   path('*.csv')
 
-  when: { params.databases.pdb?.run }
+  when: params.databases.pdb?.run
 
   script:
   """

--- a/workflows/databases/pirbase.nf
+++ b/workflows/databases/pirbase.nf
@@ -4,7 +4,7 @@ process find_urls {
   output:
   path("urls.txt")
 
-  when: { params.databases.pirbase?.run }
+  when: params.databases.pirbase?.run
 
   script:
   """
@@ -19,7 +19,7 @@ process find_known {
   output:
   path('known')
 
-  when: { params.databases.pirbase?.run }
+  when: params.databases.pirbase?.run
 
   script:
   """

--- a/workflows/databases/pirbase.nf
+++ b/workflows/databases/pirbase.nf
@@ -4,8 +4,6 @@ process find_urls {
   output:
   path("urls.txt")
 
-  when: params.databases.pirbase?.run
-
   script:
   """
   rnac pirbase urls-for $params.databases.pirbase.remote urls.txt
@@ -18,8 +16,6 @@ process find_known {
 
   output:
   path('known')
-
-  when: params.databases.pirbase?.run
 
   script:
   """
@@ -48,16 +44,21 @@ process parse_data {
 
 workflow pirbase {
   main:
-    channel.fromPath('files/import-data/pirbase/known-md5.sql') | set { query }
+    if ( params.databases.pirbase?.run ) {
+      channel.fromPath('files/import-data/pirbase/known-md5.sql') | set { query }
 
-    find_urls \
-    | splitCsv \
-    | map { row -> row[0] } \
-    | filter { url -> !url.contains('piRBase_tbe.json') } \
-    | combine(find_known(query)) \
-    | parse_data \
-    | flatten \
-    | set { data_files }
+      find_urls \
+      | splitCsv \
+      | map { row -> row[0] } \
+      | filter { url -> !url.contains('piRBase_tbe.json') } \
+      | combine(find_known(query)) \
+      | parse_data \
+      | flatten \
+      | set { data_files }
+    }
+    else {
+      channel.empty() | set { data_files }
+    }
 
   emit: data_files
 }

--- a/workflows/databases/pirbase.nf
+++ b/workflows/databases/pirbase.nf
@@ -17,7 +17,7 @@ process find_known {
   path(query)
 
   output:
-  path(known)
+  path('known')
 
   when: { params.databases.pirbase?.run }
 

--- a/workflows/databases/pirbase.nf
+++ b/workflows/databases/pirbase.nf
@@ -48,7 +48,7 @@ process parse_data {
 
 workflow pirbase {
   main:
-    Channel.fromPath('files/import-data/pirbase/known-md5.sql') | set { query }
+    channel.fromPath('files/import-data/pirbase/known-md5.sql') | set { query }
 
     find_urls \
     | splitCsv \

--- a/workflows/databases/pirbase.nf
+++ b/workflows/databases/pirbase.nf
@@ -47,7 +47,6 @@ process parse_data {
 }
 
 workflow pirbase {
-  emit: data_files
   main:
     Channel.fromPath('files/import-data/pirbase/known-md5.sql') | set { query }
 
@@ -59,4 +58,6 @@ workflow pirbase {
     | parse_data \
     | flatten \
     | set { data_files }
+
+  emit: data_files
 }

--- a/workflows/databases/plncdb.nf
+++ b/workflows/databases/plncdb.nf
@@ -37,14 +37,14 @@ process parse_data {
 workflow plncdb {
   main:
   if( params.databases.plncdb?.run ) {
-    Channel.fromPath("$params.databases.plncdb.data_path/*", type:'dir') \
+    channel.fromPath("$params.databases.plncdb.data_path/*", type:'dir') \
     | parse_data \
     | flatten
     | collectFile() {csvfile -> [csvfile.name, csvfile.text]} \
     | set { data_files }
   }
   else {
-  Channel.empty() | set { data_files }
+  channel.empty() | set { data_files }
   }
 
   emit: data_files

--- a/workflows/databases/plncdb.nf
+++ b/workflows/databases/plncdb.nf
@@ -4,7 +4,7 @@ process fetch_data {
   output:
   path("data")
 
-  when: { !params.databases.plncdb?.prefetch && params.databases.plncdb?.run }
+  when: !params.databases.plncdb?.prefetch && params.databases.plncdb?.run
 
   script:
   """
@@ -25,7 +25,7 @@ process parse_data {
   output:
   path('*.csv')
 
-  when: { params.databases.plncdb?.run }
+  when: params.databases.plncdb?.run
 
   script:
   """

--- a/workflows/databases/plncdb.nf
+++ b/workflows/databases/plncdb.nf
@@ -35,8 +35,6 @@ process parse_data {
 }
 
 workflow plncdb {
-  emit: data_files
-
   main:
   if( params.databases.plncdb?.run ) {
     Channel.fromPath("$params.databases.plncdb.data_path/*", type:'dir') \
@@ -49,5 +47,5 @@ workflow plncdb {
   Channel.empty() | set { data_files }
   }
 
-
+  emit: data_files
 }

--- a/workflows/databases/pombase.nf
+++ b/workflows/databases/pombase.nf
@@ -1,8 +1,8 @@
 process pombase {
-  when: { params.databases.pombase?.run }
-
   output:
   path('*.csv')
+
+  when: { params.databases.pombase?.run }
 
   script:
   """

--- a/workflows/databases/pombase.nf
+++ b/workflows/databases/pombase.nf
@@ -2,7 +2,7 @@ process pombase {
   output:
   path('*.csv')
 
-  when: { params.databases.pombase?.run }
+  when: params.databases.pombase?.run
 
   script:
   """

--- a/workflows/databases/psicquic.nf
+++ b/workflows/databases/psicquic.nf
@@ -1,8 +1,8 @@
 process psicquic {
-  when: { params.databases.psicquic?.run }
-
   output:
   path("*.csv")
+
+  when: { params.databases.psicquic?.run }
 
   script:
   """

--- a/workflows/databases/psicquic.nf
+++ b/workflows/databases/psicquic.nf
@@ -2,7 +2,7 @@ process psicquic {
   output:
   path("*.csv")
 
-  when: { params.databases.psicquic?.run }
+  when: params.databases.psicquic?.run
 
   script:
   """

--- a/workflows/databases/quickgo.nf
+++ b/workflows/databases/quickgo.nf
@@ -40,7 +40,7 @@ workflow quickgo {
       quickgo_get | quickgo_parse | set { data }
     }
     else {
-      Channel.empty() | set { data }
+      channel.empty() | set { data }
     }
 
   emit: data

--- a/workflows/databases/quickgo.nf
+++ b/workflows/databases/quickgo.nf
@@ -5,7 +5,7 @@ process quickgo_get {
   output:
   path('data.gpa')
 
-  when: { params.databases.quickgo?.run }
+  when: params.databases.quickgo?.run
 
   script:
   """

--- a/workflows/databases/quickgo.nf
+++ b/workflows/databases/quickgo.nf
@@ -5,8 +5,6 @@ process quickgo_get {
   output:
   path('data.gpa')
 
-  when: params.databases.quickgo?.run
-
   script:
   """
   scp $params.databases.quickgo.remote data.gpa.gz

--- a/workflows/databases/quickgo.nf
+++ b/workflows/databases/quickgo.nf
@@ -35,8 +35,6 @@ process quickgo_parse {
 
 workflow quickgo {
 
-  emit: data
-
   main:
     if ( params.databases.quickgo?.run ) {
       quickgo_get | quickgo_parse | set { data }
@@ -45,5 +43,6 @@ workflow quickgo {
       Channel.empty() | set { data }
     }
 
+  emit: data
 
 }

--- a/workflows/databases/rediportal.nf
+++ b/workflows/databases/rediportal.nf
@@ -74,7 +74,7 @@ process load_rediportal {
 }
 
 workflow rediportal {
-  take: ready
+  take: _ready
   main:
     if( params.databases.rediportal?.run ) {
       channel.fromPath("files/ftp-export/genome_coordinates/query.sql") | set { region_query }

--- a/workflows/databases/rediportal.nf
+++ b/workflows/databases/rediportal.nf
@@ -7,7 +7,7 @@ process build_rnc_bedfile {
   output:
     tuple val(assembly_id), path("rnc_regions.bed")
 
-  when: { params.databases.rediportal?.run }
+  when: params.databases.rediportal?.run
 
   script:
   """
@@ -29,7 +29,7 @@ process fetch_rediportal_inputs {
   output:
     tuple val(assembly_id), val(genome_build), path("rediportal.txt"), path("rediportal.bed")
 
-  when: { params.databases.rediportal?.run }
+  when: params.databases.rediportal?.run
 
   script:
   """

--- a/workflows/databases/rediportal.nf
+++ b/workflows/databases/rediportal.nf
@@ -7,8 +7,6 @@ process build_rnc_bedfile {
   output:
     tuple val(assembly_id), path("rnc_regions.bed")
 
-  when: params.databases.rediportal?.run
-
   script:
   """
   set -euo pipefail
@@ -28,8 +26,6 @@ process fetch_rediportal_inputs {
 
   output:
     tuple val(assembly_id), val(genome_build), path("rediportal.txt"), path("rediportal.bed")
-
-  when: params.databases.rediportal?.run
 
   script:
   """

--- a/workflows/databases/rediportal.nf
+++ b/workflows/databases/rediportal.nf
@@ -77,9 +77,9 @@ workflow rediportal {
   take: ready
   main:
     if( params.databases.rediportal?.run ) {
-      Channel.fromPath("files/ftp-export/genome_coordinates/query.sql") | set { region_query }
-      Channel.fromPath("files/rediportal/load.ctl") | set { load_query }
-      Channel
+      channel.fromPath("files/ftp-export/genome_coordinates/query.sql") | set { region_query }
+      channel.fromPath("files/rediportal/load.ctl") | set { load_query }
+      channel
         .fromList(params.databases.rediportal.inputs)
         .map { input -> tuple(input.assembly_id, input.genome_build, input.remote) }
         | set { redi_inputs }
@@ -108,7 +108,7 @@ workflow rediportal {
 
     }
     else {
-      Channel.of('rediportal not run') | set { done }
+      channel.of('rediportal not run') | set { done }
     }
 
   emit: done
@@ -116,5 +116,5 @@ workflow rediportal {
 
 
 workflow {
-  rediportal(Channel.of('ready'))
+  rediportal(channel.of('ready'))
 }

--- a/workflows/databases/refseq.nf
+++ b/workflows/databases/refseq.nf
@@ -28,7 +28,7 @@ process parse {
 
 
 workflow refseq {
-  emit: data
   main:
     fetch | flatten | parse | set { data }
+  emit: data
 }

--- a/workflows/databases/refseq.nf
+++ b/workflows/databases/refseq.nf
@@ -2,7 +2,7 @@ process fetch {
   output:
   path('*.gbff')
 
-  when: { params.databases.refseq?.run }
+  when: params.databases.refseq?.run
 
   script:
   """

--- a/workflows/databases/rfam.nf
+++ b/workflows/databases/rfam.nf
@@ -116,10 +116,10 @@ process parse {
 
 workflow rfam {
   main:
-    Channel.fromPath('files/import-data/rfam/select-families.sql') | set { family_sql }
-    Channel.fromPath('files/import-data/rfam/families.sql') | set { info_sql }
-    Channel.fromPath('files/import-data/rfam/sequences_family.sql') | set { sequence_family_sql }
-    Channel.fromPath('files/import-data/rfam/sequences_seed.sql') | set { sequence_seed_sql }
+    channel.fromPath('files/import-data/rfam/select-families.sql') | set { family_sql }
+    channel.fromPath('files/import-data/rfam/families.sql') | set { info_sql }
+    channel.fromPath('files/import-data/rfam/sequences_family.sql') | set { sequence_family_sql }
+    channel.fromPath('files/import-data/rfam/sequences_seed.sql') | set { sequence_seed_sql }
 
     info_sql | fetch_families_info | set { info }
 

--- a/workflows/databases/rfam.nf
+++ b/workflows/databases/rfam.nf
@@ -5,7 +5,7 @@ process fetch_families {
   output:
   path('families.tsv')
 
-  when: { params.databases.rfam?.run }
+  when: params.databases.rfam?.run
 
   script:
   """
@@ -25,7 +25,7 @@ process fetch_families_info {
   output:
   path("info.tsv")
 
-  when: { params.databases.rfam?.run }
+  when: params.databases.rfam?.run
 
   script:
   """

--- a/workflows/databases/rfam.nf
+++ b/workflows/databases/rfam.nf
@@ -115,7 +115,6 @@ process parse {
 
 
 workflow rfam {
-  emit: data
   main:
     Channel.fromPath('files/import-data/rfam/select-families.sql') | set { family_sql }
     Channel.fromPath('files/import-data/rfam/families.sql') | set { info_sql }
@@ -134,4 +133,5 @@ workflow rfam {
     | combine(info) \
     | parse \
     | set { data }
+  emit: data
 }

--- a/workflows/databases/rgd.nf
+++ b/workflows/databases/rgd.nf
@@ -2,7 +2,7 @@ process rgd {
   output:
   path('*.csv')
 
-  when: { params.databases.rgd?.run }
+  when: params.databases.rgd?.run
 
   script:
   """

--- a/workflows/databases/ribocentre.nf
+++ b/workflows/databases/ribocentre.nf
@@ -5,7 +5,7 @@ process fetch_ribocentre {
   output:
   path("ribocentre.json")
 
-  when: { params.databases.ribocentre?.run }
+  when: params.databases.ribocentre?.run
 
   script:
   """
@@ -22,7 +22,7 @@ process parse_ribocentre {
   output:
   path("*.csv")
 
-  when: { params.databases.ribocentre?.run }
+  when: params.databases.ribocentre?.run
 
   script:
   """

--- a/workflows/databases/ribocentre.nf
+++ b/workflows/databases/ribocentre.nf
@@ -2,9 +2,10 @@
 process fetch_ribocentre {
   memory 1.GB
 
-  when: { params.databases.ribocentre?.run }
   output:
   path("ribocentre.json")
+
+  when: { params.databases.ribocentre?.run }
 
   script:
   """
@@ -16,11 +17,12 @@ process parse_ribocentre {
   memory { 2.GB * task.attempt }
   errorStrategy { task.exitStatus in 137..140 ? 'retry' : 'terminate' }
 
-  when: { params.databases.ribocentre?.run }
   input:
   path ribocentre_json
   output:
   path("*.csv")
+
+  when: { params.databases.ribocentre?.run }
 
   script:
   """
@@ -30,8 +32,8 @@ process parse_ribocentre {
 
 
 workflow ribocentre {
-  emit: data
-
   main:
   fetch_ribocentre | parse_ribocentre | set { data }
+
+  emit: data
 }

--- a/workflows/databases/ribovision.nf
+++ b/workflows/databases/ribovision.nf
@@ -1,8 +1,8 @@
 process ribovision {
-  when: params.databases.ribovision?.run
-
   output:
   path("*.csv")
+
+  when: params.databases.ribovision?.run
 
   script:
   """

--- a/workflows/databases/select.nf
+++ b/workflows/databases/select.nf
@@ -51,7 +51,7 @@ process update_tracker_table {
 
 workflow select {
 
-  Channel.fromPath(params.import_selection_remotes) \
+  channel.fromPath(params.import_selection_remotes) \
   | splitCsv
   | map { row -> tuple(row[0], row[1])}
   | check_db_md5

--- a/workflows/databases/sgd.nf
+++ b/workflows/databases/sgd.nf
@@ -1,8 +1,8 @@
 process sgd {
-  when: { params.databases.sgd?.run }
-
   output:
   path('*.csv')
+
+  when: { params.databases.sgd?.run }
 
   script:
   """

--- a/workflows/databases/sgd.nf
+++ b/workflows/databases/sgd.nf
@@ -2,7 +2,7 @@ process sgd {
   output:
   path('*.csv')
 
-  when: { params.databases.sgd?.run }
+  when: params.databases.sgd?.run
 
   script:
   """

--- a/workflows/databases/silva.nf
+++ b/workflows/databases/silva.nf
@@ -2,7 +2,7 @@ process fetch {
   output:
   path('*.rnac')
 
-  when: { params.databases.silva?.run }
+  when: params.databases.silva?.run
 
   script:
   """

--- a/workflows/databases/snodb.nf
+++ b/workflows/databases/snodb.nf
@@ -2,7 +2,7 @@ process snodb {
   output:
   path('*.csv')
 
-  when: { params.databases.snodb?.run }
+  when: params.databases.snodb?.run
 
   script:
   """

--- a/workflows/databases/snorna_database.nf
+++ b/workflows/databases/snorna_database.nf
@@ -2,7 +2,7 @@ process snorna_database {
   output:
   path('*.csv')
 
-  when: { params.databases.snorna_database?.run }
+  when: params.databases.snorna_database?.run
 
   script:
   """

--- a/workflows/databases/snorna_database.nf
+++ b/workflows/databases/snorna_database.nf
@@ -1,8 +1,8 @@
 process snorna_database {
-  when: { params.databases.snorna_database?.run }
-
   output:
   path('*.csv')
+
+  when: { params.databases.snorna_database?.run }
 
   script:
   """

--- a/workflows/databases/tarbase.nf
+++ b/workflows/databases/tarbase.nf
@@ -15,7 +15,7 @@ process fetch {
   output:
   path('*.tsv')
 
-  when: { params.databases.tarbase?.run }
+  when: params.databases.tarbase?.run
 
   script:
   """
@@ -34,7 +34,7 @@ process parse {
   output:
   path('*.csv')
 
-  when: { params.databases.tarbase?.run }
+  when: params.databases.tarbase?.run
 
   script:
   """

--- a/workflows/databases/tarbase.nf
+++ b/workflows/databases/tarbase.nf
@@ -1,21 +1,21 @@
 workflow tarbase {
-  emit: data
-
   main:
   remotes = channel.fromList( params.databases.tarbase.remotes )
   remotes | fetch | parse | set { data }
+
+  emit: data
 }
 
 process fetch {
   errorStrategy 'retry'
   maxRetries 10
 
-  when: { params.databases.tarbase?.run }
-
   input:
   val remote
   output:
   path('*.tsv')
+
+  when: { params.databases.tarbase?.run }
 
   script:
   """
@@ -28,13 +28,13 @@ process parse {
   memory { 8.GB * task.attempt }
   errorStrategy { task.exitStatus in 137..140 ? 'retry' : 'terminate' }
 
-  when: { params.databases.tarbase?.run }
-
   input:
   path tsv_file
 
   output:
   path('*.csv')
+
+  when: { params.databases.tarbase?.run }
 
   script:
   """

--- a/workflows/databases/tmrna.nf
+++ b/workflows/databases/tmrna.nf
@@ -2,7 +2,7 @@ process tmrna {
   output:
   path('*.csv')
 
-  when: { params.databases.tmrna?.run }
+  when: params.databases.tmrna?.run
 
   script:
   """

--- a/workflows/databases/tmrna.nf
+++ b/workflows/databases/tmrna.nf
@@ -1,8 +1,8 @@
 process tmrna {
-  when: { params.databases.tmrna?.run }
-
   output:
   path('*.csv')
+
+  when: { params.databases.tmrna?.run }
 
   script:
   """

--- a/workflows/databases/zfin.nf
+++ b/workflows/databases/zfin.nf
@@ -5,7 +5,7 @@ process zfin {
   output:
   path('*.csv')
 
-  when: { params.databases.zfin?.run }
+  when: params.databases.zfin?.run
 
   script:
   """

--- a/workflows/databases/zwd.nf
+++ b/workflows/databases/zwd.nf
@@ -1,11 +1,11 @@
 process zwd {
-  when: { params.databases.zwd?.run }
-
   input:
   path(context)
 
   output:
   path('*.csv')
+
+  when: { params.databases.zwd?.run }
 
   script:
   """

--- a/workflows/databases/zwd.nf
+++ b/workflows/databases/zwd.nf
@@ -5,7 +5,7 @@ process zwd {
   output:
   path('*.csv')
 
-  when: { params.databases.zwd?.run }
+  when: params.databases.zwd?.run
 
   script:
   """

--- a/workflows/export/ftp.nf
+++ b/workflows/export/ftp.nf
@@ -9,7 +9,7 @@ include { fasta_export } from './ftp/sequences'
 include { rediportal } from './ftp/rediportal.nf'
 
 process release_note {
-  containerOptions "--contain --workdir $projectDir/work/tmp --bind $projectDir"
+  containerOptions "--contain --workdir $baseDir/work/tmp --bind $baseDir"
 
   publishDir "${params.export.ftp.publish}/", mode: 'copy'
 

--- a/workflows/export/ftp.nf
+++ b/workflows/export/ftp.nf
@@ -133,15 +133,15 @@ workflow ftp {
   take: _flag
   main:
     if (params.export.ftp.run) {
-      Channel.fromPath('files/ftp-export/md5/md5.sql') | set { md5_query }
-      Channel.fromPath('files/ftp-export/md5/readme.txt') | set { md5_template }
+      channel.fromPath('files/ftp-export/md5/md5.sql') | set { md5_query }
+      channel.fromPath('files/ftp-export/md5/readme.txt') | set { md5_template }
       md5(md5_query, md5_template)
 
-      Channel.fromPath('files/ftp-export/release_note.txt') | release_note
-      Channel.fromPath('files/ftp-export/go_annotations/rnacentral_rfam_annotations.sql') | rfam_go_matches
+      channel.fromPath('files/ftp-export/release_note.txt') | release_note
+      channel.fromPath('files/ftp-export/go_annotations/rnacentral_rfam_annotations.sql') | rfam_go_matches
 
-      Channel.fromPath('files/ftp-export/rfam/rfam-annotations.sql') | set { rfam_annotation_query }
-      Channel.fromPath('files/ftp-export/rfam/readme.txt') | set { rfam_readme }
+      channel.fromPath('files/ftp-export/rfam/rfam-annotations.sql') | set { rfam_annotation_query }
+      channel.fromPath('files/ftp-export/rfam/readme.txt') | set { rfam_readme }
       rfam_annotations(rfam_annotation_query, rfam_readme)
 
       gpi()
@@ -156,5 +156,5 @@ workflow ftp {
 }
 
 workflow {
-  ftp(Channel.of('ready'))
+  ftp(channel.of('ready'))
 }

--- a/workflows/export/ftp.nf
+++ b/workflows/export/ftp.nf
@@ -108,6 +108,7 @@ process gpi_species {
   output:
   path("rnacentral.species.gpi*")
 
+  script:
   """
   rnac ftp-export gpi --filter species rnacentral.species.gpi
   gzip -k rnacentral.species.gpi
@@ -121,6 +122,7 @@ process gpi_reference_proteome {
   output:
   path("rnacentral.reference_proteome.gpi*")
 
+  script:
   """
   rnac ftp-export gpi --filter reference-proteome rnacentral.reference_proteome.gpi
   gzip -k rnacentral.reference_proteome.gpi

--- a/workflows/export/ftp.nf
+++ b/workflows/export/ftp.nf
@@ -9,7 +9,7 @@ include { fasta_export } from './ftp/sequences'
 include { rediportal } from './ftp/rediportal.nf'
 
 process release_note {
-  containerOptions "--contain --workdir $baseDir/work/tmp --bind $baseDir"
+  containerOptions "--contain --workdir $projectDir/work/tmp --bind $projectDir"
 
   publishDir "${params.export.ftp.publish}/", mode: 'copy'
 

--- a/workflows/export/ftp/coordinates.nf
+++ b/workflows/export/ftp/coordinates.nf
@@ -137,10 +137,10 @@ process index_gff3 {
 }
 
 workflow export_coordinates {
-  Channel.fromPath('files/ftp-export/genome_coordinates/known-coordinates.sql') | set { known }
-  Channel.fromPath('files/ftp-export/genome_coordinates/query.sql') | set { query }
+  channel.fromPath('files/ftp-export/genome_coordinates/known-coordinates.sql') | set { known }
+  channel.fromPath('files/ftp-export/genome_coordinates/query.sql') | set { query }
 
-  readme(Channel.fromPath('files/ftp-export/genome_coordinates/readme.mkd'))
+  readme(channel.fromPath('files/ftp-export/genome_coordinates/readme.mkd'))
 
   known \
   | find_jobs \

--- a/workflows/export/ftp/ensembl.nf
+++ b/workflows/export/ftp/ensembl.nf
@@ -41,8 +41,8 @@ process process_chunk {
 }
 
 workflow ensembl_export {
-  Channel.fromPath('files/ftp-export/ensembl/schema.json') | set { schema }
-  Channel.fromPath('files/ftp-export/ensembl/ensembl-xrefs.sql') | set { query }
+  channel.fromPath('files/ftp-export/ensembl/schema.json') | set { schema }
+  channel.fromPath('files/ftp-export/ensembl/ensembl-xrefs.sql') | set { query }
 
   find_chunks \
   | splitCsv \

--- a/workflows/export/ftp/id-mapping.nf
+++ b/workflows/export/ftp/id-mapping.nf
@@ -43,7 +43,7 @@ process merge_id_mapping {
 
 process database_mapping {
   publishDir "${params.export.ftp.publish}/id_mapping/database_mappings/", mode: 'copy'
-  containerOptions "--contain --workdir $projectDir/work/tmp --bind $projectDir"
+  containerOptions "--contain --workdir $baseDir/work/tmp --bind $baseDir"
 
   input:
   path('id_mapping.tsv.gz')

--- a/workflows/export/ftp/id-mapping.nf
+++ b/workflows/export/ftp/id-mapping.nf
@@ -60,10 +60,10 @@ process database_mapping {
 }
 
 workflow id_mapping {
-  Channel.fromPath('files/ftp-export/id-mapping/id_mapping.sql') | set { id_query }
-  Channel.fromPath('files/ftp-export/id-mapping/readme.txt') | set { readme_template }
+  channel.fromPath('files/ftp-export/id-mapping/id_mapping.sql') | set { id_query }
+  channel.fromPath('files/ftp-export/id-mapping/readme.txt') | set { readme_template }
 
-  Channel.of('0','1','2','3','4','5','6','7','8','9','a','b','c','d','e','f') \
+  channel.of('0','1','2','3','4','5','6','7','8','9','a','b','c','d','e','f') \
   | combine(id_query) \
   | build_id_mapping_chunk \
   | collect \

--- a/workflows/export/ftp/id-mapping.nf
+++ b/workflows/export/ftp/id-mapping.nf
@@ -43,7 +43,7 @@ process merge_id_mapping {
 
 process database_mapping {
   publishDir "${params.export.ftp.publish}/id_mapping/database_mappings/", mode: 'copy'
-  containerOptions "--contain --workdir $baseDir/work/tmp --bind $baseDir"
+  containerOptions "--contain --workdir $projectDir/work/tmp --bind $projectDir"
 
   input:
   path('id_mapping.tsv.gz')

--- a/workflows/export/ftp/rediportal.nf
+++ b/workflows/export/ftp/rediportal.nf
@@ -15,7 +15,7 @@ process dump {
 
 workflow rediportal {
 
-  Channel.fromPath('files/ftp-export/rediportal/editing-locations.sql') | set { query }
+  channel.fromPath('files/ftp-export/rediportal/editing-locations.sql') | set { query }
 
   query | dump
 

--- a/workflows/export/ftp/sequences.nf
+++ b/workflows/export/ftp/sequences.nf
@@ -257,25 +257,25 @@ PYEOF
 }
 
 workflow fasta_export {
-  Channel.fromPath('files/ftp-export/sequences/active.sql') | set { active_sql }
-  Channel.fromPath('files/ftp-export/sequences/readme.txt') | set { readme }
+  channel.fromPath('files/ftp-export/sequences/active.sql') | set { active_sql }
+  channel.fromPath('files/ftp-export/sequences/readme.txt') | set { readme }
   active(active_sql, readme)
 
-  Channel.fromPath('files/ftp-export/sequences/inactive.sql') | inactive
-  Channel.fromPath('files/ftp-export/sequences/species-specific.sql') \
+  channel.fromPath('files/ftp-export/sequences/inactive.sql') | inactive
+  channel.fromPath('files/ftp-export/sequences/species-specific.sql') \
   | species_specific \
   | (compress_species_fasta & create_ssi)
 
-  Channel.fromPath('files/ftp-export/sequences/databases.sql') \
+  channel.fromPath('files/ftp-export/sequences/databases.sql') \
   | find_dbs \
   | splitCsv \
-  | combine(Channel.fromPath('files/ftp-export/sequences/database-specific.sql')) \
+  | combine(channel.fromPath('files/ftp-export/sequences/database-specific.sql')) \
   | database_specific
 
-  Channel.fromPath('files/ftp-export/sequences/species.sql') \
+  channel.fromPath('files/ftp-export/sequences/species.sql') \
   | find_species \
   | combine(species_specific.out) \
   | split_by_species
 
-  Channel.fromPath('files/ftp-export/sequences/by-species-readme.txt') | by_species_readme
+  channel.fromPath('files/ftp-export/sequences/by-species-readme.txt') | by_species_readme
 }

--- a/workflows/export/sequence-search.nf
+++ b/workflows/export/sequence-search.nf
@@ -2,8 +2,6 @@
 
 nextflow.enable.dsl=2
 
-create_memory = params.export.sequence_search.create_fasta.memory_table
-
 process find_db_to_export {
   input:
   path(query)
@@ -41,7 +39,7 @@ process query_database {
 
 process create_fasta {
   tag { name }
-  memory { create_memory.get(name.replaceAll("-", "_"), create_memory.__default) }
+  memory { def cm = params.export.sequence_search.create_fasta.memory_table; cm.get(name.replaceAll("-", "_"), cm.__default) }
 
   input:
   tuple val(name), path(json)

--- a/workflows/export/sequence-search.nf
+++ b/workflows/export/sequence-search.nf
@@ -9,7 +9,7 @@ process find_db_to_export {
   output:
   path('dbs.txt')
 
-  when: { params.export?.sequence_search?.run }
+  when: params.export?.sequence_search?.run
 
   script:
   """

--- a/workflows/export/sequence-search.nf
+++ b/workflows/export/sequence-search.nf
@@ -103,10 +103,10 @@ process atomic_publish {
 workflow sequence_search {
   take: _flag
   main:
-    Channel.fromPath('files/ftp-export/sequences/databases.sql') | set { db_query }
-    Channel.fromPath('files/ftp-export/sequences/database-specific.sql') | set { db_specific_query }
+    channel.fromPath('files/ftp-export/sequences/databases.sql') | set { db_query }
+    channel.fromPath('files/ftp-export/sequences/database-specific.sql') | set { db_specific_query }
 
-    Channel.fromPath('files/sequence-search-export/*.sql') \
+    channel.fromPath('files/sequence-search-export/*.sql') \
     | filter { params.export.sequence_search.run } \
     | map { fn -> [file(fn).baseName, fn, ''] } \
     | set { simple_queries }
@@ -130,5 +130,5 @@ workflow sequence_search {
 }
 
 workflow {
-  sequence_search(Channel.of('ready'))
+  sequence_search(channel.of('ready'))
 }

--- a/workflows/export/sequence-search.nf
+++ b/workflows/export/sequence-search.nf
@@ -5,13 +5,13 @@ nextflow.enable.dsl=2
 create_memory = params.export.sequence_search.create_fasta.memory_table
 
 process find_db_to_export {
-  when: { params.export?.sequence_search?.run }
-
   input:
   path(query)
 
   output:
   path('dbs.txt')
+
+  when: { params.export?.sequence_search?.run }
 
   script:
   """

--- a/workflows/export/text-search.nf
+++ b/workflows/export/text-search.nf
@@ -55,7 +55,7 @@ process atomic_publish {
 workflow text_search {
   take: _flag
   main:
-    Channel.fromPath('files/search-export/post-publish.sql') | set { post }
+    channel.fromPath('files/search-export/post-publish.sql') | set { post }
 
     sequences()
 
@@ -77,5 +77,5 @@ workflow text_search {
 }
 
 workflow {
-  text_search(Channel.of('ready'))
+  text_search(channel.of('ready'))
 }

--- a/workflows/export/text-search.nf
+++ b/workflows/export/text-search.nf
@@ -6,7 +6,7 @@ include { sequences } from './text-search/sequences'
 include { genes } from './text-search/genes'
 
 process create_release_note {
-  containerOptions "--contain --workdir $projectDir/work/tmp --bind $projectDir"
+  containerOptions "--contain --workdir $baseDir/work/tmp --bind $baseDir"
 
   input:
   path('count*')

--- a/workflows/export/text-search.nf
+++ b/workflows/export/text-search.nf
@@ -6,7 +6,7 @@ include { sequences } from './text-search/sequences'
 include { genes } from './text-search/genes'
 
 process create_release_note {
-  containerOptions "--contain --workdir $baseDir/work/tmp --bind $baseDir"
+  containerOptions "--contain --workdir $projectDir/work/tmp --bind $projectDir"
 
   input:
   path('count*')

--- a/workflows/export/text-search/build-accession-table.nf
+++ b/workflows/export/text-search/build-accession-table.nf
@@ -61,8 +61,8 @@ process finalize_accession_table {
 workflow build_search_accessions {
   take: ready
   main:
-    Channel.fromPath('files/search-export/build-accessions/insert.sql') | set { chunk_sql }
-    Channel.fromPath('files/search-export/build-accessions/post-insert.sql') | set { post_sql }
+    channel.fromPath('files/search-export/build-accessions/insert.sql') | set { chunk_sql }
+    channel.fromPath('files/search-export/build-accessions/post-insert.sql') | set { post_sql }
 
     find_partitions | splitCsv | set { partitions }
 

--- a/workflows/export/text-search/build-accession-table.nf
+++ b/workflows/export/text-search/build-accession-table.nf
@@ -73,7 +73,7 @@ workflow build_search_accessions {
     | build_accession_table \
     | collect \
     | combine(post_sql) \
-    | map { it[-1] } \
+    | map { row -> row[-1] } \
     | finalize_accession_table \
     | set { built }
   emit: built

--- a/workflows/export/text-search/genes.nf
+++ b/workflows/export/text-search/genes.nf
@@ -29,7 +29,7 @@ process as_xml {
   memory { params.export.search.memory * task.attempt }
   errorStrategy { task.exitStatus in 137..140 ? 'retry' : 'finish' }
   maxRetries 3
-  containerOptions "--contain --workdir $baseDir/work/tmp --bind $baseDir"
+  containerOptions "--contain --workdir $projectDir/work/tmp --bind $projectDir"
 
   input:
   tuple val(assembly), path('raw*.json'), path('so_tree.json'), path('schema.xsd')

--- a/workflows/export/text-search/genes.nf
+++ b/workflows/export/text-search/genes.nf
@@ -26,7 +26,7 @@ process merge_and_split {
 
 process as_xml {
   tag { "$assembly" }
-  memory { (params.export.search.memory as nextflow.util.MemoryUnit) * task.attempt }
+  memory { params.export.search.memory * task.attempt }
   errorStrategy { task.exitStatus in 137..140 ? 'retry' : 'finish' }
   maxRetries 3
   containerOptions "--contain --workdir $baseDir/work/tmp --bind $baseDir"

--- a/workflows/export/text-search/genes.nf
+++ b/workflows/export/text-search/genes.nf
@@ -29,7 +29,7 @@ process as_xml {
   memory { params.export.search.memory * task.attempt }
   errorStrategy { task.exitStatus in 137..140 ? 'retry' : 'finish' }
   maxRetries 3
-  containerOptions "--contain --workdir $projectDir/work/tmp --bind $projectDir"
+  containerOptions "--contain --workdir $baseDir/work/tmp --bind $baseDir"
 
   input:
   tuple val(assembly), path('raw*.json'), path('so_tree.json'), path('schema.xsd')

--- a/workflows/export/text-search/genes.nf
+++ b/workflows/export/text-search/genes.nf
@@ -56,7 +56,7 @@ workflow genes {
     sequence_json
     so_tree
   main:
-    Channel.fromPath('files/search-export/genes/region-info.sql') | set { locus_sql }
+    channel.fromPath('files/search-export/genes/region-info.sql') | set { locus_sql }
 
     locus_query(max_count, locus_sql) | set { locus_info }
     fetch_schema()

--- a/workflows/export/text-search/sequences.nf
+++ b/workflows/export/text-search/sequences.nf
@@ -206,12 +206,6 @@ process as_xml {
 }
 
 workflow sequences {
-  emit:
-    xml
-    counts
-    search_count
-    sequence_json
-    so_tree
   main:
     Channel.fromPath('files/search-export/setup.sql') | set { setup_sql }
 
@@ -283,4 +277,10 @@ workflow sequences {
     as_xml.out.sequences | set { sequence_json }
     as_xml.out.counts | set { counts }
     as_xml.out.xml | set { xml }
+  emit:
+    xml
+    counts
+    search_count
+    sequence_json
+    so_tree
 }

--- a/workflows/export/text-search/sequences.nf
+++ b/workflows/export/text-search/sequences.nf
@@ -20,7 +20,7 @@ include { fetch_schema } from './utils'
 include { build_search_accessions } from './build-accession-table'
 
 process setup {
-  containerOptions "--contain --workdir $baseDir/work/tmp --bind $baseDir"
+  containerOptions "--contain --workdir $projectDir/work/tmp --bind $projectDir"
 
   input:
   path(sql)
@@ -37,7 +37,7 @@ process setup {
 }
 
 process fetch_so_tree {
-  containerOptions "--contain --workdir $baseDir/work/tmp --bind $baseDir"
+  containerOptions "--contain --workdir $projectDir/work/tmp --bind $projectDir"
 
   input:
   path(query)
@@ -186,7 +186,7 @@ process as_xml {
   memory { params.export.search.memory * task.attempt }
   errorStrategy { task.exitStatus in 137..140 ? 'retry' : 'finish' }
   maxRetries 3
-  containerOptions "--contain --workdir $baseDir/work/tmp --bind $baseDir"
+  containerOptions "--contain --workdir $projectDir/work/tmp --bind $projectDir"
 
   input:
   tuple val(min), val(max), path(raw), path(metadata), path('schema.xsd')

--- a/workflows/export/text-search/sequences.nf
+++ b/workflows/export/text-search/sequences.nf
@@ -119,10 +119,11 @@ process fetch_accession {
 }
 
 process text_mining_query {
+  container ''
+
   input:
   val(max_count)
   path(script)
-  container ''
 
   output:
   path("publication-count.json")

--- a/workflows/export/text-search/sequences.nf
+++ b/workflows/export/text-search/sequences.nf
@@ -20,7 +20,7 @@ include { fetch_schema } from './utils'
 include { build_search_accessions } from './build-accession-table'
 
 process setup {
-  containerOptions "--contain --workdir $projectDir/work/tmp --bind $projectDir"
+  containerOptions "--contain --workdir $baseDir/work/tmp --bind $baseDir"
 
   input:
   path(sql)
@@ -37,7 +37,7 @@ process setup {
 }
 
 process fetch_so_tree {
-  containerOptions "--contain --workdir $projectDir/work/tmp --bind $projectDir"
+  containerOptions "--contain --workdir $baseDir/work/tmp --bind $baseDir"
 
   input:
   path(query)
@@ -186,7 +186,7 @@ process as_xml {
   memory { params.export.search.memory * task.attempt }
   errorStrategy { task.exitStatus in 137..140 ? 'retry' : 'finish' }
   maxRetries 3
-  containerOptions "--contain --workdir $projectDir/work/tmp --bind $projectDir"
+  containerOptions "--contain --workdir $baseDir/work/tmp --bind $baseDir"
 
   input:
   tuple val(min), val(max), path(raw), path(metadata), path('schema.xsd')

--- a/workflows/export/text-search/sequences.nf
+++ b/workflows/export/text-search/sequences.nf
@@ -183,7 +183,7 @@ process editing_events {
 
 process as_xml {
   tag { "$min-$max" }
-  memory { (params.export.search.memory as nextflow.util.MemoryUnit) * task.attempt }
+  memory { params.export.search.memory * task.attempt }
   errorStrategy { task.exitStatus in 137..140 ? 'retry' : 'finish' }
   maxRetries 3
   containerOptions "--contain --workdir $baseDir/work/tmp --bind $baseDir"

--- a/workflows/export/text-search/sequences.nf
+++ b/workflows/export/text-search/sequences.nf
@@ -208,28 +208,28 @@ process as_xml {
 
 workflow sequences {
   main:
-    Channel.fromPath('files/search-export/setup.sql') | set { setup_sql }
+    channel.fromPath('files/search-export/setup.sql') | set { setup_sql }
 
-    Channel.fromPath('files/search-export/parts/base.sql') | set { base_sql }
-    Channel.fromPath('files/search-export/parts/crs.sql') | set { crs_sql }
-    Channel.fromPath('files/search-export/parts/feedback.sql') | set { feeback_sql }
-    Channel.fromPath('files/search-export/parts/go-annotations.sql') | set { go_sql }
-    Channel.fromPath('files/search-export/parts/interacting-proteins.sql') | set { prot_sql }
-    Channel.fromPath('files/search-export/parts/interacting-rnas.sql') | set { rnas_sql }
-    Channel.fromPath('files/search-export/parts/precompute.sql') | set { precompute_sql }
-    Channel.fromPath('files/search-export/parts/qa-status.sql') | set { qa_sql }
-    Channel.fromPath('files/search-export/parts/r2dt.sql') | set { r2dt_sql }
-    Channel.fromPath('files/search-export/parts/rfam-hits.sql') | set { rfam_sql }
-    Channel.fromPath('files/search-export/parts/orfs.sql') | set { orf_sql }
-    Channel.fromPath('files/search-export/parts/text-mining.sql') | set { text_sql }
-    Channel.fromPath('files/search-export/parts/litsumm.sql') | set { litsumm_sql }
-    Channel.fromPath('files/search-export/parts/editing-events.sql') | set { editing_events_sql }
-    Channel.fromPath('files/search-export/parts/goflow.sql') | set { goflow_sql }
-    Channel.fromPath('files/search-export/so-rna-types.sql') | set { so_sql }
+    channel.fromPath('files/search-export/parts/base.sql') | set { base_sql }
+    channel.fromPath('files/search-export/parts/crs.sql') | set { crs_sql }
+    channel.fromPath('files/search-export/parts/feedback.sql') | set { feeback_sql }
+    channel.fromPath('files/search-export/parts/go-annotations.sql') | set { go_sql }
+    channel.fromPath('files/search-export/parts/interacting-proteins.sql') | set { prot_sql }
+    channel.fromPath('files/search-export/parts/interacting-rnas.sql') | set { rnas_sql }
+    channel.fromPath('files/search-export/parts/precompute.sql') | set { precompute_sql }
+    channel.fromPath('files/search-export/parts/qa-status.sql') | set { qa_sql }
+    channel.fromPath('files/search-export/parts/r2dt.sql') | set { r2dt_sql }
+    channel.fromPath('files/search-export/parts/rfam-hits.sql') | set { rfam_sql }
+    channel.fromPath('files/search-export/parts/orfs.sql') | set { orf_sql }
+    channel.fromPath('files/search-export/parts/text-mining.sql') | set { text_sql }
+    channel.fromPath('files/search-export/parts/litsumm.sql') | set { litsumm_sql }
+    channel.fromPath('files/search-export/parts/editing-events.sql') | set { editing_events_sql }
+    channel.fromPath('files/search-export/parts/goflow.sql') | set { goflow_sql }
+    channel.fromPath('files/search-export/so-rna-types.sql') | set { so_sql }
 
-    Channel.fromPath('files/search-export/parts/accessions.sql') | set { accessions_sql }
+    channel.fromPath('files/search-export/parts/accessions.sql') | set { accessions_sql }
 
-    Channel.fromPath('files/search-export/get-counts.sql') | set { counts_sql }
+    channel.fromPath('files/search-export/get-counts.sql') | set { counts_sql }
 
     setup(setup_sql, counts_sql)
     | splitCsv \

--- a/workflows/export/text-search/utils.nf
+++ b/workflows/export/text-search/utils.nf
@@ -1,5 +1,5 @@
 process fetch_schema {
-  containerOptions "--contain --workdir $baseDir/work/tmp --bind $baseDir"
+  containerOptions "--contain --workdir $projectDir/work/tmp --bind $projectDir"
   errorStrategy 'retry'
   maxRetries 3
 
@@ -14,7 +14,7 @@ process fetch_schema {
 
 process fetch {
   tag { "${query.baseName}" }
-  containerOptions "--contain --workdir $baseDir/work/tmp --bind $baseDir"
+  containerOptions "--contain --workdir $projectDir/work/tmp --bind $projectDir"
 
   input:
   val(max_count)
@@ -32,7 +32,7 @@ process fetch {
 process group {
   memory params.search_export.memory
   tag { "${name}" }
-  containerOptions "--contain --workdir $baseDir/work/tmp --bind $baseDir"
+  containerOptions "--contain --workdir $projectDir/work/tmp --bind $projectDir"
 
   input:
   tuple val(name), path("raw.json"), val(max_count)

--- a/workflows/export/text-search/utils.nf
+++ b/workflows/export/text-search/utils.nf
@@ -1,5 +1,5 @@
 process fetch_schema {
-  containerOptions "--contain --workdir $projectDir/work/tmp --bind $projectDir"
+  containerOptions "--contain --workdir $baseDir/work/tmp --bind $baseDir"
   errorStrategy 'retry'
   maxRetries 3
 
@@ -14,7 +14,7 @@ process fetch_schema {
 
 process fetch {
   tag { "${query.baseName}" }
-  containerOptions "--contain --workdir $projectDir/work/tmp --bind $projectDir"
+  containerOptions "--contain --workdir $baseDir/work/tmp --bind $baseDir"
 
   input:
   val(max_count)
@@ -32,7 +32,7 @@ process fetch {
 process group {
   memory params.search_export.memory
   tag { "${name}" }
-  containerOptions "--contain --workdir $projectDir/work/tmp --bind $projectDir"
+  containerOptions "--contain --workdir $baseDir/work/tmp --bind $baseDir"
 
   input:
   tuple val(name), path("raw.json"), val(max_count)

--- a/workflows/genome-mapping.nf
+++ b/workflows/genome-mapping.nf
@@ -251,12 +251,12 @@ process load_mapping {
 workflow genome_mapping {
   take: ready
   main:
-    Channel.fromPath('files/genome-mapping/find_species.sql').set { find_species }
-    Channel.fromPath('files/genome-mapping/possible.sql').set { possible_sql }
-    Channel.fromPath('files/genome-mapping/get-mapped.sql').set { mapped_sql }
-    Channel.fromPath('files/genome-mapping/find-unmapped.sql').set { unmapped_sql }
-    Channel.fromPath('files/genome-mapping/load.ctl').set { hits_ctl }
-    Channel.fromPath('files/genome-mapping/attempted.ctl').set { attempted_ctl }
+    channel.fromPath('files/genome-mapping/find_species.sql').set { find_species }
+    channel.fromPath('files/genome-mapping/possible.sql').set { possible_sql }
+    channel.fromPath('files/genome-mapping/get-mapped.sql').set { mapped_sql }
+    channel.fromPath('files/genome-mapping/find-unmapped.sql').set { unmapped_sql }
+    channel.fromPath('files/genome-mapping/load.ctl').set { hits_ctl }
+    channel.fromPath('files/genome-mapping/attempted.ctl').set { attempted_ctl }
 
     if (params.genome_mapping.run) {
       setup(ready, find_species) \
@@ -298,11 +298,11 @@ workflow genome_mapping {
 
       load_mapping(hits, hits_ctl, attempted, attempted_ctl) | set { done }
     } else {
-      Channel.of('genome-mapping skipped') | set { done }
+      channel.of('genome-mapping skipped') | set { done }
     }
   emit: done
 }
 
 workflow {
-  genome_mapping(Channel.from('ready'))
+  genome_mapping(channel.from('ready'))
 }

--- a/workflows/genome-mapping.nf
+++ b/workflows/genome-mapping.nf
@@ -174,7 +174,7 @@ process index_genome_for_browser {
 process blat {
   tag { "${species}-${genome.baseName}-${chunk.baseName}" }
   memory { params.genome_mapping.blat.directives.memory }
-  errorStrategy =  { task.exitStatus in [137, 140, 143] ? 'retry' : 'ignore' }
+  errorStrategy { task.exitStatus in [137, 140, 143] ? 'retry' : 'ignore' }
   time { task.attempt == 1 ? 15.m : task.attempt == 2? 60.m : 24.h }
   maxRetries 3
 

--- a/workflows/genome-mapping.nf
+++ b/workflows/genome-mapping.nf
@@ -10,7 +10,7 @@ process setup {
   output:
   path('species.csv')
 
-  when: { params.genome_mapping?.run }
+  when: params.genome_mapping?.run
 
   script:
   """

--- a/workflows/genome-mapping.nf
+++ b/workflows/genome-mapping.nf
@@ -3,14 +3,14 @@
 nextflow.enable.dsl = 2
 
 process setup {
-  when: { params.genome_mapping?.run }
-
   input:
   val(_flag)
   path(query)
 
   output:
   path('species.csv')
+
+  when: { params.genome_mapping?.run }
 
   script:
   """

--- a/workflows/genome-mapping.nf
+++ b/workflows/genome-mapping.nf
@@ -261,7 +261,7 @@ workflow genome_mapping {
     if (params.genome_mapping.run) {
       setup(ready, find_species) \
       | splitCsv \
-      | filter { s, a, t, d -> !params.genome_mapping.species_excluded_from_mapping.contains(s) } \
+      | filter { s, _a, _t, _d -> !params.genome_mapping.species_excluded_from_mapping.contains(s) } \
       | set { genome_info }
 
       genome_info \
@@ -290,7 +290,7 @@ workflow genome_mapping {
           .combinations()
           .inject([]) { acc, files -> acc << [species, assembly] + files.flatten() }
       } \
-      | filter { s, a, g, o, chunk -> !chunk.isEmpty() } \
+      | filter { _s, _a, _g, _o, chunk -> !chunk.isEmpty() } \
       | blat
 
       blat.out.hits | groupTuple | select_mapped_locations | collect | set { hits }

--- a/workflows/igv-urls.nf
+++ b/workflows/igv-urls.nf
@@ -51,7 +51,7 @@ process merge_json {
 workflow genome_mapping {
   take: ready
   main:
-    Channel.fromPath('files/genome-mapping/find_species.sql').set { find_species }
+    channel.fromPath('files/genome-mapping/find_species.sql').set { find_species }
 
     setup(ready, find_species) \
     | splitCsv \
@@ -62,5 +62,5 @@ workflow genome_mapping {
 }
 
 workflow {
-  genome_mapping(Channel.from('ready'))
+  genome_mapping(channel.from('ready'))
 }

--- a/workflows/igv-urls.nf
+++ b/workflows/igv-urls.nf
@@ -55,7 +55,7 @@ workflow genome_mapping {
 
     setup(ready, find_species) \
     | splitCsv \
-    | filter { s, a, t, d -> !params.genome_mapping.species_excluded_from_mapping.contains(s) } \
+    | filter { s, _a, _t, _d -> !params.genome_mapping.species_excluded_from_mapping.contains(s) } \
     | set { genome_info }
 
     genome_info | create_json | collect | merge_json

--- a/workflows/litscan/litscan-export-articles.nf
+++ b/workflows/litscan/litscan-export-articles.nf
@@ -13,7 +13,7 @@ process create_xml_files {
     script:
     """
     rm -fr "$params.litscan_index"/references_*
-    litscan-get-articles.py "$PSYCOPG_CONN" $params.litscan_index
+    litscan-get-articles.py "\$PSYCOPG_CONN" $params.litscan_index
     """
 }
 
@@ -25,5 +25,5 @@ workflow export_articles {
 }
 
 workflow {
-  export_articles()
+  export_articles(channel.of('ready'))
 }

--- a/workflows/litscan/litscan-export-metadata.nf
+++ b/workflows/litscan/litscan-export-metadata.nf
@@ -14,7 +14,7 @@ process create_metadata {
 }
 
 process merge_metadata {
-    publishDir "$projectDir/workflows/litscan/metadata/", mode: 'copy'
+    publishDir "$baseDir/workflows/litscan/metadata/", mode: 'copy'
 
     input:
     file(results)
@@ -24,8 +24,8 @@ process merge_metadata {
 
     script:
     """
-    if [[ -f $projectDir/workflows/litscan/metadata/rfam/extra-ids.txt ]]; then
-      cat $projectDir/workflows/litscan/metadata/rfam/extra-ids.txt > merged_metadata
+    if [[ -f $baseDir/workflows/litscan/metadata/rfam/extra-ids.txt ]]; then
+      cat $baseDir/workflows/litscan/metadata/rfam/extra-ids.txt > merged_metadata
     fi
 
     cat $results | sort -fb | uniq -i >> merged_metadata
@@ -79,7 +79,7 @@ process load_database_table {
 }
 
 process get_statistics {
-    publishDir "$projectDir/workflows/litscan/metadata/", mode: 'copy'
+    publishDir "$baseDir/workflows/litscan/metadata/", mode: 'copy'
 
     input:
     val(_flag)
@@ -117,10 +117,10 @@ workflow export_metadata {
 
       create_xml(metadata) | create_release_file
 
-      load = channel.of("$projectDir/workflows/litscan/metadata/load-metadata.ctl")
+      load = channel.of("$baseDir/workflows/litscan/metadata/load-metadata.ctl")
       load_database_table(metadata, load) | get_statistics | set{ statistics }
 
-      load_statistics = channel.of("$projectDir/workflows/litscan/metadata/load-statistics.ctl")
+      load_statistics = channel.of("$baseDir/workflows/litscan/metadata/load-statistics.ctl")
       save_statistics(statistics, load_statistics)
 }
 

--- a/workflows/litscan/litscan-export-metadata.nf
+++ b/workflows/litscan/litscan-export-metadata.nf
@@ -45,7 +45,7 @@ process create_xml {
     script:
     """
     rm -f "$params.litscan_index"/metadata*
-    litscan-create-xml-metadata.py "$PSYCOPG_CONN" $merged_metadata metadata_*
+    litscan-create-xml-metadata.py "\$PSYCOPG_CONN" $merged_metadata metadata_*
     """
 }
 
@@ -89,7 +89,7 @@ process get_statistics {
 
     script:
     """
-    litscan-get-statistics.py "$PSYCOPG_CONN" statistics.csv
+    litscan-get-statistics.py "\$PSYCOPG_CONN" statistics.csv
     """
 }
 
@@ -104,7 +104,7 @@ process save_statistics {
     script:
     """
     pgloader --on-error-stop $ctl
-    curl -X POST -H 'Content-type: application/json' --data '{"text":"LitScan workflow completed"}' $LITSCAN_SLACK_WEBHOOK
+    curl -X POST -H 'Content-type: application/json' --data '{"text":"LitScan workflow completed"}' \$LITSCAN_SLACK_WEBHOOK
     """
 }
 

--- a/workflows/litscan/litscan-export-metadata.nf
+++ b/workflows/litscan/litscan-export-metadata.nf
@@ -112,18 +112,18 @@ process save_statistics {
 workflow export_metadata {
     take: ready
     main:
-      database = Channel.fromPath('workflows/litscan/results/*.txt')
+      database = channel.fromPath('workflows/litscan/results/*.txt')
       database | combine(ready) | create_metadata | collect | merge_metadata | set{ metadata }
 
       create_xml(metadata) | create_release_file
 
-      load = Channel.of("$baseDir/workflows/litscan/metadata/load-metadata.ctl")
+      load = channel.of("$baseDir/workflows/litscan/metadata/load-metadata.ctl")
       load_database_table(metadata, load) | get_statistics | set{ statistics }
 
-      load_statistics = Channel.of("$baseDir/workflows/litscan/metadata/load-statistics.ctl")
+      load_statistics = channel.of("$baseDir/workflows/litscan/metadata/load-statistics.ctl")
       save_statistics(statistics, load_statistics)
 }
 
 workflow {
-  export_metadata(Channel.of('ready'))
+  export_metadata(channel.of('ready'))
 }

--- a/workflows/litscan/litscan-export-metadata.nf
+++ b/workflows/litscan/litscan-export-metadata.nf
@@ -14,7 +14,7 @@ process create_metadata {
 }
 
 process merge_metadata {
-    publishDir "$baseDir/workflows/litscan/metadata/", mode: 'copy'
+    publishDir "$projectDir/workflows/litscan/metadata/", mode: 'copy'
 
     input:
     file(results)
@@ -24,8 +24,8 @@ process merge_metadata {
 
     script:
     """
-    if [[ -f $baseDir/workflows/litscan/metadata/rfam/extra-ids.txt ]]; then
-      cat $baseDir/workflows/litscan/metadata/rfam/extra-ids.txt > merged_metadata
+    if [[ -f $projectDir/workflows/litscan/metadata/rfam/extra-ids.txt ]]; then
+      cat $projectDir/workflows/litscan/metadata/rfam/extra-ids.txt > merged_metadata
     fi
 
     cat $results | sort -fb | uniq -i >> merged_metadata
@@ -79,7 +79,7 @@ process load_database_table {
 }
 
 process get_statistics {
-    publishDir "$baseDir/workflows/litscan/metadata/", mode: 'copy'
+    publishDir "$projectDir/workflows/litscan/metadata/", mode: 'copy'
 
     input:
     val(_flag)
@@ -117,10 +117,10 @@ workflow export_metadata {
 
       create_xml(metadata) | create_release_file
 
-      load = channel.of("$baseDir/workflows/litscan/metadata/load-metadata.ctl")
+      load = channel.of("$projectDir/workflows/litscan/metadata/load-metadata.ctl")
       load_database_table(metadata, load) | get_statistics | set{ statistics }
 
-      load_statistics = channel.of("$baseDir/workflows/litscan/metadata/load-statistics.ctl")
+      load_statistics = channel.of("$projectDir/workflows/litscan/metadata/load-statistics.ctl")
       save_statistics(statistics, load_statistics)
 }
 

--- a/workflows/litscan/litscan-find-organisms.nf
+++ b/workflows/litscan/litscan-find-organisms.nf
@@ -33,10 +33,10 @@ process save_organisms {
 workflow find_organisms {
     take: ready
     main:
-      query = Channel.of("$baseDir/workflows/litscan/organisms/get-organisms.sql")
+      query = channel.of("$baseDir/workflows/litscan/organisms/get-organisms.sql")
       get_organisms(ready, query) | set{ organism_pmcid }
 
-      save_ctl = Channel.of("$baseDir/workflows/litscan/organisms/save-organisms.ctl")
+      save_ctl = channel.of("$baseDir/workflows/litscan/organisms/save-organisms.ctl")
       save_organisms(organism_pmcid, save_ctl) | set{ done }
     emit: done
 }

--- a/workflows/litscan/litscan-find-organisms.nf
+++ b/workflows/litscan/litscan-find-organisms.nf
@@ -12,7 +12,7 @@ process get_organisms {
 
     script:
     """
-    psql -v ON_ERROR_STOP=1 -f $query $PGDB_EMBASSY_USER > organism_pmcid
+    psql -v ON_ERROR_STOP=1 -f $query \$PGDB_EMBASSY_USER > organism_pmcid
     """
 }
 
@@ -42,5 +42,5 @@ workflow find_organisms {
 }
 
 workflow {
-  find_organisms()
+  find_organisms(channel.of('ready'))
 }

--- a/workflows/litscan/litscan-find-organisms.nf
+++ b/workflows/litscan/litscan-find-organisms.nf
@@ -1,7 +1,7 @@
 nextflow.enable.dsl=2
 
 process get_organisms {
-    publishDir "$baseDir/workflows/litscan/organisms/", mode: 'copy'
+    publishDir "$projectDir/workflows/litscan/organisms/", mode: 'copy'
 
     input:
     val(_flag)
@@ -33,10 +33,10 @@ process save_organisms {
 workflow find_organisms {
     take: ready
     main:
-      query = channel.of("$baseDir/workflows/litscan/organisms/get-organisms.sql")
+      query = channel.of("$projectDir/workflows/litscan/organisms/get-organisms.sql")
       get_organisms(ready, query) | set{ organism_pmcid }
 
-      save_ctl = channel.of("$baseDir/workflows/litscan/organisms/save-organisms.ctl")
+      save_ctl = channel.of("$projectDir/workflows/litscan/organisms/save-organisms.ctl")
       save_organisms(organism_pmcid, save_ctl) | set{ done }
     emit: done
 }

--- a/workflows/litscan/litscan-find-organisms.nf
+++ b/workflows/litscan/litscan-find-organisms.nf
@@ -1,7 +1,7 @@
 nextflow.enable.dsl=2
 
 process get_organisms {
-    publishDir "$projectDir/workflows/litscan/organisms/", mode: 'copy'
+    publishDir "$baseDir/workflows/litscan/organisms/", mode: 'copy'
 
     input:
     val(_flag)
@@ -33,10 +33,10 @@ process save_organisms {
 workflow find_organisms {
     take: ready
     main:
-      query = channel.of("$projectDir/workflows/litscan/organisms/get-organisms.sql")
+      query = channel.of("$baseDir/workflows/litscan/organisms/get-organisms.sql")
       get_organisms(ready, query) | set{ organism_pmcid }
 
-      save_ctl = channel.of("$projectDir/workflows/litscan/organisms/save-organisms.ctl")
+      save_ctl = channel.of("$baseDir/workflows/litscan/organisms/save-organisms.ctl")
       save_organisms(organism_pmcid, save_ctl) | set{ done }
     emit: done
 }

--- a/workflows/litscan/litscan-load-organisms.nf
+++ b/workflows/litscan/litscan-load-organisms.nf
@@ -57,5 +57,5 @@ workflow load_organisms {
 }
 
 workflow {
-  load_organisms()
+  load_organisms(channel.of('ready'))
 }

--- a/workflows/litscan/litscan-load-organisms.nf
+++ b/workflows/litscan/litscan-load-organisms.nf
@@ -15,7 +15,7 @@ process get_organisms {
 
 process create_csv {
     memory '4GB'
-    publishDir "$baseDir/workflows/litscan/organisms/", mode: 'copy'
+    publishDir "$projectDir/workflows/litscan/organisms/", mode: 'copy'
 
     input:
     file(organism_textmining_mentions)
@@ -50,7 +50,7 @@ workflow load_organisms {
       | create_csv
       | set{ organism_pmid }
 
-      load_ctl = channel.of("$baseDir/workflows/litscan/organisms/load-organisms.ctl")
+      load_ctl = channel.of("$projectDir/workflows/litscan/organisms/load-organisms.ctl")
       import_organisms(organism_pmid, load_ctl) \
       | set{ done }
     emit: done

--- a/workflows/litscan/litscan-load-organisms.nf
+++ b/workflows/litscan/litscan-load-organisms.nf
@@ -50,7 +50,7 @@ workflow load_organisms {
       | create_csv
       | set{ organism_pmid }
 
-      load_ctl = Channel.of("$baseDir/workflows/litscan/organisms/load-organisms.ctl")
+      load_ctl = channel.of("$baseDir/workflows/litscan/organisms/load-organisms.ctl")
       import_organisms(organism_pmid, load_ctl) \
       | set{ done }
     emit: done

--- a/workflows/litscan/litscan-load-organisms.nf
+++ b/workflows/litscan/litscan-load-organisms.nf
@@ -15,7 +15,7 @@ process get_organisms {
 
 process create_csv {
     memory '4GB'
-    publishDir "$projectDir/workflows/litscan/organisms/", mode: 'copy'
+    publishDir "$baseDir/workflows/litscan/organisms/", mode: 'copy'
 
     input:
     file(organism_textmining_mentions)
@@ -50,7 +50,7 @@ workflow load_organisms {
       | create_csv
       | set{ organism_pmid }
 
-      load_ctl = channel.of("$projectDir/workflows/litscan/organisms/load-organisms.ctl")
+      load_ctl = channel.of("$baseDir/workflows/litscan/organisms/load-organisms.ctl")
       import_organisms(organism_pmid, load_ctl) \
       | set{ done }
     emit: done

--- a/workflows/litscan/litscan-manually-annotated.nf
+++ b/workflows/litscan/litscan-manually-annotated.nf
@@ -28,7 +28,7 @@ process sort_expert_db_articles {
 }
 
 process find_manually_annotated_articles {
-    publishDir "$projectDir/workflows/litscan/manually_annotated/", mode: 'copy'
+    publishDir "$baseDir/workflows/litscan/manually_annotated/", mode: 'copy'
 
     input:
     file(sorted_results)
@@ -65,7 +65,7 @@ workflow find_manually_annotated {
       | find_manually_annotated_articles \
       | set{ manually_annotated_articles }
 
-      load_ctl = channel.of("$projectDir/workflows/litscan/manually_annotated/save-manually-annotated.ctl")
+      load_ctl = channel.of("$baseDir/workflows/litscan/manually_annotated/save-manually-annotated.ctl")
       import_manually_annotated_articles(manually_annotated_articles, load_ctl) | set{ done }
     emit: done
 }

--- a/workflows/litscan/litscan-manually-annotated.nf
+++ b/workflows/litscan/litscan-manually-annotated.nf
@@ -10,7 +10,7 @@ process get_expert_db_articles {
 
     script:
     """
-    psql -t -A -f $query "$PGDB_EMBASSY_USER" > results
+    psql -t -A -f $query "\$PGDB_EMBASSY_USER" > results
     """
 }
 
@@ -38,7 +38,7 @@ process find_manually_annotated_articles {
 
     script:
     """
-    litscan-manually-annotated.py "$PSYCOPG_CONN" $sorted_results manually_annotated_articles
+    litscan-manually-annotated.py "\$PSYCOPG_CONN" $sorted_results manually_annotated_articles
     """
 }
 
@@ -71,5 +71,5 @@ workflow find_manually_annotated {
 }
 
 workflow {
-  find_manually_annotated()
+  find_manually_annotated(channel.of('ready'))
 }

--- a/workflows/litscan/litscan-manually-annotated.nf
+++ b/workflows/litscan/litscan-manually-annotated.nf
@@ -59,13 +59,13 @@ process import_manually_annotated_articles {
 workflow find_manually_annotated {
     take: ready
     main:
-      query = Channel.fromPath('workflows/litscan/manually_annotated/query.sql')
+      query = channel.fromPath('workflows/litscan/manually_annotated/query.sql')
       get_expert_db_articles(ready, query) \
       | sort_expert_db_articles \
       | find_manually_annotated_articles \
       | set{ manually_annotated_articles }
 
-      load_ctl = Channel.of("$baseDir/workflows/litscan/manually_annotated/save-manually-annotated.ctl")
+      load_ctl = channel.of("$baseDir/workflows/litscan/manually_annotated/save-manually-annotated.ctl")
       import_manually_annotated_articles(manually_annotated_articles, load_ctl) | set{ done }
     emit: done
 }

--- a/workflows/litscan/litscan-manually-annotated.nf
+++ b/workflows/litscan/litscan-manually-annotated.nf
@@ -28,7 +28,7 @@ process sort_expert_db_articles {
 }
 
 process find_manually_annotated_articles {
-    publishDir "$baseDir/workflows/litscan/manually_annotated/", mode: 'copy'
+    publishDir "$projectDir/workflows/litscan/manually_annotated/", mode: 'copy'
 
     input:
     file(sorted_results)
@@ -65,7 +65,7 @@ workflow find_manually_annotated {
       | find_manually_annotated_articles \
       | set{ manually_annotated_articles }
 
-      load_ctl = channel.of("$baseDir/workflows/litscan/manually_annotated/save-manually-annotated.ctl")
+      load_ctl = channel.of("$projectDir/workflows/litscan/manually_annotated/save-manually-annotated.ctl")
       import_manually_annotated_articles(manually_annotated_articles, load_ctl) | set{ done }
     emit: done
 }

--- a/workflows/litscan/litscan-rescan-ids-by-date.nf
+++ b/workflows/litscan/litscan-rescan-ids-by-date.nf
@@ -21,5 +21,5 @@ workflow rescan_ids_by_date {
 }
 
 workflow {
-    rescan_ids_by_date(Channel.from('ready'))
+    rescan_ids_by_date(channel.from('ready'))
 }

--- a/workflows/litscan/litscan-rescan-ids-by-date.nf
+++ b/workflows/litscan/litscan-rescan-ids-by-date.nf
@@ -9,7 +9,7 @@ process change_status_to_pending {
 
     script:
     """
-    psql -c "UPDATE litscan_job j SET status='pending' FROM ( SELECT DISTINCT job_id FROM litscan_database WHERE name IN $params.rescan_ids_from ) d WHERE j.job_id = d.job_id;" $PGDB_EMBASSY_USER
+    psql -c "UPDATE litscan_job j SET status='pending' FROM ( SELECT DISTINCT job_id FROM litscan_database WHERE name IN $params.rescan_ids_from ) d WHERE j.job_id = d.job_id;" \$PGDB_EMBASSY_USER
     """
 }
 

--- a/workflows/litscan/litscan-retracted-articles.nf
+++ b/workflows/litscan/litscan-retracted-articles.nf
@@ -9,7 +9,7 @@ process check_articles {
 
     script:
     """
-    litscan-retracted-articles.py "$PSYCOPG_CONN" $LITSCAN_SLACK_WEBHOOK
+    litscan-retracted-articles.py "\$PSYCOPG_CONN" \$LITSCAN_SLACK_WEBHOOK
     """
 }
 
@@ -21,5 +21,5 @@ workflow find_retracted_articles {
 }
 
 workflow {
-    find_retracted_articles()
+    find_retracted_articles(channel.of('ready'))
 }

--- a/workflows/litscan/litscan-search-new-ids.nf
+++ b/workflows/litscan/litscan-search-new-ids.nf
@@ -38,7 +38,7 @@ process check_ids {
 }
 
 process sort_ids {
-    publishDir "$projectDir/workflows/litscan/results/", mode: 'copy'
+    publishDir "$baseDir/workflows/litscan/results/", mode: 'copy'
 
     input:
     tuple val(database), file(output)
@@ -54,7 +54,7 @@ process sort_ids {
 
 process prepare_to_submit {
     memory '2GB'
-    publishDir "$projectDir/workflows/litscan/submit/", mode: 'copy'
+    publishDir "$baseDir/workflows/litscan/submit/", mode: 'copy'
 
     input:
     tuple val(database), path("${database}.txt")
@@ -78,7 +78,7 @@ process submit_ids {
     script:
     """
     # create file with IDs (without URS)
-    find $projectDir/workflows/litscan/submit/ -name "*.txt" -print0 | xargs -0 sed '/^URS/d' > all_ids.txt
+    find $baseDir/workflows/litscan/submit/ -name "*.txt" -print0 | xargs -0 sed '/^URS/d' > all_ids.txt
     tr A-Z a-z < all_ids.txt | sort -u > all_ids_sorted.txt
 
     # get ids already scanned by LitScan (Expert DB ids only)
@@ -117,7 +117,7 @@ process submit_urs {
     script:
     """
     # create file with URS only
-    find $projectDir/workflows/litscan/submit/ -name "*.txt" -print0 | xargs -0 sed '/^URS/!d' > output.txt
+    find $baseDir/workflows/litscan/submit/ -name "*.txt" -print0 | xargs -0 sed '/^URS/!d' > output.txt
     tr a-z A-Z < output.txt | sort -u > urs.txt
 
     # get URS already scanned by LitScan

--- a/workflows/litscan/litscan-search-new-ids.nf
+++ b/workflows/litscan/litscan-search-new-ids.nf
@@ -38,7 +38,7 @@ process check_ids {
 }
 
 process sort_ids {
-    publishDir "$baseDir/workflows/litscan/results/", mode: 'copy'
+    publishDir "$projectDir/workflows/litscan/results/", mode: 'copy'
 
     input:
     tuple val(database), file(output)
@@ -54,7 +54,7 @@ process sort_ids {
 
 process prepare_to_submit {
     memory '2GB'
-    publishDir "$baseDir/workflows/litscan/submit/", mode: 'copy'
+    publishDir "$projectDir/workflows/litscan/submit/", mode: 'copy'
 
     input:
     tuple val(database), path("${database}.txt")
@@ -78,7 +78,7 @@ process submit_ids {
     script:
     """
     # create file with IDs (without URS)
-    find $baseDir/workflows/litscan/submit/ -name "*.txt" -print0 | xargs -0 sed '/^URS/d' > all_ids.txt
+    find $projectDir/workflows/litscan/submit/ -name "*.txt" -print0 | xargs -0 sed '/^URS/d' > all_ids.txt
     tr A-Z a-z < all_ids.txt | sort -u > all_ids_sorted.txt
 
     # get ids already scanned by LitScan (Expert DB ids only)
@@ -117,7 +117,7 @@ process submit_urs {
     script:
     """
     # create file with URS only
-    find $baseDir/workflows/litscan/submit/ -name "*.txt" -print0 | xargs -0 sed '/^URS/!d' > output.txt
+    find $projectDir/workflows/litscan/submit/ -name "*.txt" -print0 | xargs -0 sed '/^URS/!d' > output.txt
     tr a-z A-Z < output.txt | sort -u > urs.txt
 
     # get URS already scanned by LitScan

--- a/workflows/litscan/litscan-search-new-ids.nf
+++ b/workflows/litscan/litscan-search-new-ids.nf
@@ -141,7 +141,6 @@ process submit_urs {
 }
 
 workflow search_new_ids {
-    emit: done
     main:
       Channel.of("Starting LitScan pipeline") | slack_message
 
@@ -154,6 +153,7 @@ workflow search_new_ids {
       | submit_ids \
       | submit_urs \
       | set { done }
+    emit: done
 }
 
 workflow {

--- a/workflows/litscan/litscan-search-new-ids.nf
+++ b/workflows/litscan/litscan-search-new-ids.nf
@@ -7,7 +7,7 @@ process slack_message {
     script:
     """
     #!/bin/bash
-    curl -X POST -H 'Content-type: application/json' --data '{"text":"$message"}' $LITSCAN_SLACK_WEBHOOK
+    curl -X POST -H 'Content-type: application/json' --data '{"text":"$message"}' \$LITSCAN_SLACK_WEBHOOK
     """
 }
 
@@ -20,7 +20,7 @@ process get_ids {
 
     script:
     """
-    psql -t -A -f $database "$PGDB_EMBASSY_USER" > results
+    psql -t -A -f $database "\$PGDB_EMBASSY_USER" > results
     """
 }
 
@@ -102,7 +102,7 @@ process submit_ids {
       curl -X POST -H 'Content-type: application/json' --data '{"text":"'\${count}' new id/gene/synonym submitted"}' \$LITSCAN_SLACK_WEBHOOK
     else
       # new_ids.txt is empty
-      curl -X POST -H 'Content-type: application/json' --data '{"text":"No new id/gene/synonym to submit"}' $LITSCAN_SLACK_WEBHOOK
+      curl -X POST -H 'Content-type: application/json' --data '{"text":"No new id/gene/synonym to submit"}' \$LITSCAN_SLACK_WEBHOOK
     fi
     """
 }
@@ -135,7 +135,7 @@ process submit_urs {
       curl -X POST -H 'Content-type: application/json' --data '{"text":"'\${count}' new URS submitted"}' \$LITSCAN_SLACK_WEBHOOK
     else
       # new_urs.txt is empty
-      curl -X POST -H 'Content-type: application/json' --data '{"text":"No new URS to submit"}' $LITSCAN_SLACK_WEBHOOK
+      curl -X POST -H 'Content-type: application/json' --data '{"text":"No new URS to submit"}' \$LITSCAN_SLACK_WEBHOOK
     fi
     """
 }

--- a/workflows/litscan/litscan-search-new-ids.nf
+++ b/workflows/litscan/litscan-search-new-ids.nf
@@ -142,9 +142,9 @@ process submit_urs {
 
 workflow search_new_ids {
     main:
-      Channel.of("Starting LitScan pipeline") | slack_message
+      channel.of("Starting LitScan pipeline") | slack_message
 
-      Channel.fromPath('workflows/litscan/queries/*.sql') \
+      channel.fromPath('workflows/litscan/queries/*.sql') \
       | get_ids \
       | check_ids \
       | sort_ids \

--- a/workflows/load-data.nf
+++ b/workflows/load-data.nf
@@ -1,7 +1,7 @@
 process create_load_tables {
   time '1h'
   cache false
-  containerOptions "--contain --workdir $projectDir/work/tmp --bind $projectDir"
+  containerOptions "--contain --workdir $baseDir/work/tmp --bind $baseDir"
 
   input:
   file(create)
@@ -21,7 +21,7 @@ process merge_and_import {
   maxForks 2
   cpus 4
   cache false
-  containerOptions "--contain --workdir $projectDir/work/tmp --bind $projectDir"
+  containerOptions "--contain --workdir $baseDir/work/tmp --bind $baseDir"
 
   input:
   tuple val(name), path(ctl), path('raw*.csv')
@@ -39,7 +39,7 @@ process release {
   time '5d'
   maxForks 1
   cache false
-  containerOptions "--contain --workdir $projectDir/work/tmp --bind $projectDir"
+  containerOptions "--contain --workdir $baseDir/work/tmp --bind $baseDir"
   memory  4.GB
 
   input:

--- a/workflows/load-data.nf
+++ b/workflows/load-data.nf
@@ -107,13 +107,13 @@ workflow load_data {
     | set { imported_names }
 
     imported_names
-      .flatMap { n -> file("files/import-data/pre-release/*__${n.replace('_', '-')}.sql") }
+      .flatMap { n -> files("files/import-data/pre-release/*__${n.replace('_', '-')}.sql") }
       .filter { f -> f.exists() }
       .toList()
       .set { pre_scripts }
 
     imported_names
-      .flatMap { n -> file("files/import-data/post-release/*__${n.replace('_', '-')}.sql") }
+      .flatMap { n -> files("files/import-data/post-release/*__${n.replace('_', '-')}.sql") }
       .mix(
         channel.fromPath([
           'files/import-data/post-release/000__populate_precompute.sql',

--- a/workflows/load-data.nf
+++ b/workflows/load-data.nf
@@ -50,7 +50,7 @@ process release {
   output:
   val('done')
 
-  when: { params.get('should_release', false) }
+  when: params.get('should_release', false)
 
   script:
   def should_release = params.should_release

--- a/workflows/load-data.nf
+++ b/workflows/load-data.nf
@@ -1,7 +1,7 @@
 process create_load_tables {
   time '1h'
   cache false
-  containerOptions "--contain --workdir $baseDir/work/tmp --bind $baseDir"
+  containerOptions "--contain --workdir $projectDir/work/tmp --bind $projectDir"
 
   input:
   file(create)
@@ -21,7 +21,7 @@ process merge_and_import {
   maxForks 2
   cpus 4
   cache false
-  containerOptions "--contain --workdir $baseDir/work/tmp --bind $baseDir"
+  containerOptions "--contain --workdir $projectDir/work/tmp --bind $projectDir"
 
   input:
   tuple val(name), path(ctl), path('raw*.csv')
@@ -39,7 +39,7 @@ process release {
   time '5d'
   maxForks 1
   cache false
-  containerOptions "--contain --workdir $baseDir/work/tmp --bind $baseDir"
+  containerOptions "--contain --workdir $projectDir/work/tmp --bind $projectDir"
   memory  4.GB
 
   input:

--- a/workflows/load-data.nf
+++ b/workflows/load-data.nf
@@ -82,8 +82,8 @@ process release {
 workflow load_data {
   take: parsed
   main:
-    Channel.fromPath('files/import-data/limits.json') | set { limits }
-    Channel.fromPath('files/schema/create_load.sql') | set { schema }
+    channel.fromPath('files/import-data/limits.json') | set { limits }
+    channel.fromPath('files/schema/create_load.sql') | set { schema }
 
     parsed \
     | filter { f -> !f.isEmpty() } \
@@ -115,7 +115,7 @@ workflow load_data {
     imported_names
       .flatMap { n -> file("files/import-data/post-release/*__${n.replace('_', '-')}.sql") }
       .mix(
-        Channel.fromPath([
+        channel.fromPath([
           'files/import-data/post-release/000__populate_precompute.sql',
           'files/import-data/post-release/999__cleanup.sql',
         ])

--- a/workflows/load-data.nf
+++ b/workflows/load-data.nf
@@ -92,15 +92,15 @@ workflow load_data {
       def ctl = file("files/import-data/load/${name.replace('_', '-')}.ctl")
       [[name, ctl], f]
     } \
-    | filter {
-      def status = it[0][1].exists()
+    | filter { entry ->
+      def status = entry[0][1].exists()
       if (!status) {
-        log.info "Skipping data ${it[0][1].getBaseName()}"
+        log.info "Skipping data ${entry[0][1].getBaseName()}"
       }
       status
     } \
     | groupTuple \
-    | map { [it[0][0], it[0][1], it[1]] } \
+    | map { t -> [t[0][0], t[0][1], t[1]] } \
     | combine(create_load_tables(schema)) \
     | map { n, ctl, fs, _ready -> [n, ctl, fs] } \
     | merge_and_import \

--- a/workflows/load-data.nf
+++ b/workflows/load-data.nf
@@ -42,8 +42,6 @@ process release {
   containerOptions "--contain --workdir $baseDir/work/tmp --bind $baseDir"
   memory  4.GB
 
-  when: { params.get('should_release', false) }
-
   input:
   path(pre_sql)
   path(post_sql)
@@ -51,6 +49,8 @@ process release {
 
   output:
   val('done')
+
+  when: { params.get('should_release', false) }
 
   script:
   def should_release = params.should_release

--- a/workflows/lookup-references.nf
+++ b/workflows/lookup-references.nf
@@ -23,7 +23,7 @@ process fetch_publications {
   output:
   path('out')
 
-  when: { params.get('needs_publications', false) }
+  when: params.get('needs_publications', false)
 
   script:
   """

--- a/workflows/lookup-references.nf
+++ b/workflows/lookup-references.nf
@@ -61,7 +61,7 @@ workflow lookup_ref_ids {
       | lookup_publications \
       | set { publications }
     } else {
-      Channel.empty() | set { publications }
+      channel.empty() | set { publications }
     }
 
   emit: publications

--- a/workflows/metadata/ensembl.nf
+++ b/workflows/metadata/ensembl.nf
@@ -106,16 +106,16 @@ workflow compara {
 
 workflow ensembl {
   main:
-    Channel.fromPath('config/databases.json') | set { conn }
+    channel.fromPath('config/databases.json') | set { conn }
 
-    Channel.fromPath('files/import-data/ensembl/proteins.sql') | set { protein_sql }
-    Channel.fromPath('files/import-data/ensembl/coordinate-systems.sql') | set { coordinate_systems_sql }
+    channel.fromPath('files/import-data/ensembl/proteins.sql') | set { protein_sql }
+    channel.fromPath('files/import-data/ensembl/coordinate-systems.sql') | set { coordinate_systems_sql }
 
-    Channel.fromPath('files/import-data/ensembl/assemblies.sql') | set { assemblies_sql }
-    Channel.fromPath('files/import-data/ensembl/example-locations.json') | set { examples }
-    Channel.fromPath('files/import-data/ensembl/known-assemblies.sql') | set { known }
+    channel.fromPath('files/import-data/ensembl/assemblies.sql') | set { assemblies_sql }
+    channel.fromPath('files/import-data/ensembl/example-locations.json') | set { examples }
+    channel.fromPath('files/import-data/ensembl/known-assemblies.sql') | set { known }
 
-    Channel.empty() \
+    channel.empty() \
     | mix(
       assemblies(conn, assemblies_sql, examples, known),
       coordinate_systems(conn, coordinate_systems_sql),

--- a/workflows/metadata/ensembl.nf
+++ b/workflows/metadata/ensembl.nf
@@ -1,7 +1,4 @@
 process assemblies {
-  when:
-  params.databases.ensembl?.vertebrates?.run
-
   input:
   path(connections)
   path(query)
@@ -10,6 +7,9 @@ process assemblies {
 
   output:
   path('*.csv')
+
+  when:
+  params.databases.ensembl?.vertebrates?.run
 
   script:
   """
@@ -49,14 +49,14 @@ process process_compara {
 }
 
 process proteins {
-  when: { params.databases.ensembl?.vertebrates?.run || params.databases.tarbase?.run || params.databases.lncbase?.run }
-
   input:
   path(connections)
   path(query)
 
   output:
   path('proteins.csv')
+
+  when: { params.databases.ensembl?.vertebrates?.run || params.databases.tarbase?.run || params.databases.lncbase?.run }
 
   script:
   """
@@ -99,13 +99,12 @@ process karyotypes {
 }
 
 workflow compara {
-  emit: data
   main:
     fetch_compara | flatten | process_compara | set { data }
+  emit: data
 }
 
 workflow ensembl {
-  emit: data
   main:
     Channel.fromPath('config/databases.json') | set { conn }
 
@@ -126,4 +125,5 @@ workflow ensembl {
     ) \
     | flatten \
     | set { data }
+  emit: data
 }

--- a/workflows/metadata/ensembl.nf
+++ b/workflows/metadata/ensembl.nf
@@ -24,7 +24,7 @@ process fetch_compara {
   output:
   path('*.nt.fasta.gz')
 
-  when: { params.databases.ensembl?.vertebrates?.run }
+  when: params.databases.ensembl?.vertebrates?.run
 
   script:
   """
@@ -56,7 +56,7 @@ process proteins {
   output:
   path('proteins.csv')
 
-  when: { params.databases.ensembl?.vertebrates?.run || params.databases.tarbase?.run || params.databases.lncbase?.run }
+  when: params.databases.ensembl?.vertebrates?.run || params.databases.tarbase?.run || params.databases.lncbase?.run
 
   script:
   """
@@ -75,7 +75,7 @@ process coordinate_systems {
   output:
   path('coordinate_systems.csv')
 
-  when: { params.databases.ensembl?.vertebrates?.run }
+  when: params.databases.ensembl?.vertebrates?.run
 
   script:
   """
@@ -90,7 +90,7 @@ process karyotypes {
   output:
   path('karyotypes.csv')
 
-  when: { params.databases.ensembl?.vertebrates?.run }
+  when: params.databases.ensembl?.vertebrates?.run
 
   script:
   """

--- a/workflows/metadata/rfam.nf
+++ b/workflows/metadata/rfam.nf
@@ -24,7 +24,7 @@ process generic {
 
 workflow rfam {
   main:
-    Channel.fromPath('files/import-data/rfam/{clans,families}.sql') \
+    channel.fromPath('files/import-data/rfam/{clans,families}.sql') \
     | map { fn -> [fn.baseName, fn] } \
     | generic \
     | flatten \

--- a/workflows/metadata/rfam.nf
+++ b/workflows/metadata/rfam.nf
@@ -7,7 +7,7 @@ process generic {
   output:
   path('*.csv')
 
-  when: { params.databases.ensembl?.vertebrates?.run || params.databases.rfam?.run }
+  when: params.databases.ensembl?.vertebrates?.run || params.databases.rfam?.run
 
   script:
   def conn = params.connections.rfam

--- a/workflows/metadata/rfam.nf
+++ b/workflows/metadata/rfam.nf
@@ -1,13 +1,13 @@
 process generic {
   tag { "$name" }
 
-  when: { params.databases.ensembl?.vertebrates?.run || params.databases.rfam?.run }
-
   input:
   tuple val(name), path(query)
 
   output:
   path('*.csv')
+
+  when: { params.databases.ensembl?.vertebrates?.run || params.databases.rfam?.run }
 
   script:
   def conn = params.connections.rfam
@@ -23,11 +23,11 @@ process generic {
 }
 
 workflow rfam {
-  emit: data
   main:
     Channel.fromPath('files/import-data/rfam/{clans,families}.sql') \
     | map { fn -> [fn.baseName, fn] } \
     | generic \
     | flatten \
     | set { data }
+  emit: data
 }

--- a/workflows/parse-databases.nf
+++ b/workflows/parse-databases.nf
@@ -65,10 +65,10 @@ workflow parse_databases {
       build_context | set { context }
     }
     else {
-      Channel.empty() | set { context }
+      channel.empty() | set { context }
     }
 
-    Channel.empty() \
+    channel.empty() \
     | mix(
       circatlas(),
       circpedia(),

--- a/workflows/parse-databases.nf
+++ b/workflows/parse-databases.nf
@@ -59,7 +59,6 @@ process build_context {
 }
 
 workflow parse_databases {
-  emit: data
   main:
 
     if (params.get('needs_taxonomy', false)) {
@@ -115,4 +114,5 @@ workflow parse_databases {
     ) \
     | flatten \
     | set { data }
+  emit: data
 }

--- a/workflows/parse-metadata.nf
+++ b/workflows/parse-metadata.nf
@@ -3,7 +3,6 @@ include { ensembl } from './metadata/ensembl'
 include { taxonomy } from './metadata/taxonomy'
 
 workflow parse_metadata {
-  emit: data
   main:
     Channel.empty() \
     | mix(
@@ -13,4 +12,5 @@ workflow parse_metadata {
     ) \
     | flatten \
     | set { data }
+  emit: data
 }

--- a/workflows/parse-metadata.nf
+++ b/workflows/parse-metadata.nf
@@ -4,11 +4,11 @@ include { taxonomy } from './metadata/taxonomy'
 
 workflow parse_metadata {
   main:
-    Channel.empty() \
+    channel.empty() \
     | mix(
       rfam(),
-      params.databases.ensembl._any.run ? ensembl() : Channel.empty(),
-      params.needs_taxonomy ? taxonomy() : Channel.empty(),
+      params.databases.ensembl._any.run ? ensembl() : channel.empty(),
+      params.needs_taxonomy ? taxonomy() : channel.empty(),
     ) \
     | flatten \
     | set { data }

--- a/workflows/precompute/accessions.nf
+++ b/workflows/precompute/accessions.nf
@@ -80,9 +80,9 @@ process finalize_accession_table {
 workflow build_precompute_accessions {
   take: ready
   main:
-    Channel.fromPath('files/precompute/get-accessions/insert-chunk.sql') | set { chunk_sql }
-    Channel.fromPath('files/precompute/get-accessions/post-insert.sql') | set { post_sql }
-    Channel.fromPath('files/precompute/get-accessions/insert-xref-only.sql') | set { xref_only_sql }
+    channel.fromPath('files/precompute/get-accessions/insert-chunk.sql') | set { chunk_sql }
+    channel.fromPath('files/precompute/get-accessions/post-insert.sql') | set { post_sql }
+    channel.fromPath('files/precompute/get-accessions/insert-xref-only.sql') | set { xref_only_sql }
 
     find_partitions | splitCsv | set { partitions }
 

--- a/workflows/precompute/accessions.nf
+++ b/workflows/precompute/accessions.nf
@@ -100,7 +100,7 @@ workflow build_precompute_accessions {
     | mix(xref_only) \
     | collect \
     | combine(post_sql) \
-    | map { it[-1] } \
+    | map { row -> row[-1] } \
     | finalize_accession_table \
     | set { built }
   emit: built

--- a/workflows/precompute/build_urs_table.nf
+++ b/workflows/precompute/build_urs_table.nf
@@ -188,11 +188,11 @@ workflow build_urs_table {
       create_schema(schema_sql) \
       | combine(method) \
       | map { _flag, method_val -> method_val } \
-      | branch {
-        release: it == 'release'
-        query: it == 'query'
-        all: it == 'all'
-        ids: it == 'ids'
+      | branch { v ->
+        release: v == 'release'
+        query: v == 'query'
+        all: v == 'all'
+        ids: v == 'ids'
       } \
       | set { to_build }
 

--- a/workflows/precompute/build_urs_table.nf
+++ b/workflows/precompute/build_urs_table.nf
@@ -1,6 +1,6 @@
 process create_schema {
   executor 'local'
-  containerOptions "--contain --workdir $projectDir/work/tmp --bind $projectDir"
+  containerOptions "--contain --workdir $baseDir/work/tmp --bind $baseDir"
 
   input:
   path(sql)
@@ -15,7 +15,7 @@ process create_schema {
 }
 
 process fetch_all_urs_taxid {
-  containerOptions "--contain --workdir $projectDir/work/tmp --bind $projectDir"
+  containerOptions "--contain --workdir $baseDir/work/tmp --bind $baseDir"
 
   input:
   path(query)
@@ -30,7 +30,7 @@ process fetch_all_urs_taxid {
 }
 
 process select_outdated {
-  containerOptions "--contain --workdir $projectDir/work/tmp --bind $projectDir"
+  containerOptions "--contain --workdir $baseDir/work/tmp --bind $baseDir"
   memory '24 GB'
   cpus 4
 
@@ -49,7 +49,7 @@ process select_outdated {
 
 process run_query {
   tag { "$query.baseName" }
-  containerOptions "--contain --workdir $projectDir/work/tmp --bind $projectDir"
+  containerOptions "--contain --workdir $baseDir/work/tmp --bind $baseDir"
 
   input:
   val(_flag)
@@ -65,7 +65,7 @@ process run_query {
 }
 
 process build_table {
-  containerOptions "--contain --workdir $projectDir/work/tmp --bind $projectDir"
+  containerOptions "--contain --workdir $baseDir/work/tmp --bind $baseDir"
   memory '10GB'
 
   input:
@@ -87,7 +87,7 @@ process build_table {
 }
 
 process sort_ids {
-  containerOptions "--contain --workdir $projectDir/work/tmp --bind $projectDir"
+  containerOptions "--contain --workdir $baseDir/work/tmp --bind $baseDir"
 
   input:
   val(_flag)

--- a/workflows/precompute/build_urs_table.nf
+++ b/workflows/precompute/build_urs_table.nf
@@ -133,8 +133,8 @@ process precompute_releases {
 workflow using_release {
     take: flag
     main:
-      Channel.fromPath('files/precompute/fetch-xref-info.sql') | set { xref_sql }
-      Channel.fromPath('files/precompute/fetch-precompute-info.sql') | set { pre_sql }
+      channel.fromPath('files/precompute/fetch-xref-info.sql') | set { xref_sql }
+      channel.fromPath('files/precompute/fetch-precompute-info.sql') | set { pre_sql }
 
       precompute_releases(flag, pre_sql) | set { precompute_info }
       xref_releases(flag, xref_sql) | set { xref_info }
@@ -157,7 +157,7 @@ workflow using_query {
 workflow using_all {
   take: flag
   main:
-    Channel.fromPath("files/precompute/methods/all.sql") | set { to_select }
+    channel.fromPath("files/precompute/methods/all.sql") | set { to_select }
 
     run_query(flag, to_select) | set { selected }
   emit: selected
@@ -178,10 +178,10 @@ workflow using_ids {
 workflow build_urs_table {
     take: method
     main:
-      Channel.fromPath('files/precompute/schema.sql') | set { schema_sql }
-      Channel.fromPath('files/precompute/load-urs.sql') | set { load_sql }
-      Channel.fromPath('files/all-active-urs-taxid.sql') | set { active_sql }
-      Channel.fromPath('files/precompute/get-urs-count.sql') | set { count_sql }
+      channel.fromPath('files/precompute/schema.sql') | set { schema_sql }
+      channel.fromPath('files/precompute/load-urs.sql') | set { load_sql }
+      channel.fromPath('files/all-active-urs-taxid.sql') | set { active_sql }
+      channel.fromPath('files/precompute/get-urs-count.sql') | set { count_sql }
 
       fetch_all_urs_taxid(active_sql) | set { active_urs }
 
@@ -201,7 +201,7 @@ workflow build_urs_table {
       to_build.all | using_all | set { from_all }
       to_build.ids | using_ids | set { from_ids }
 
-      Channel.empty() \
+      channel.empty() \
       | mix(from_release, from_query, from_all, from_ids) \
       | collect \
       | combine(load_sql) \

--- a/workflows/precompute/build_urs_table.nf
+++ b/workflows/precompute/build_urs_table.nf
@@ -1,6 +1,6 @@
 process create_schema {
   executor 'local'
-  containerOptions "--contain --workdir $baseDir/work/tmp --bind $baseDir"
+  containerOptions "--contain --workdir $projectDir/work/tmp --bind $projectDir"
 
   input:
   path(sql)
@@ -15,7 +15,7 @@ process create_schema {
 }
 
 process fetch_all_urs_taxid {
-  containerOptions "--contain --workdir $baseDir/work/tmp --bind $baseDir"
+  containerOptions "--contain --workdir $projectDir/work/tmp --bind $projectDir"
 
   input:
   path(query)
@@ -30,7 +30,7 @@ process fetch_all_urs_taxid {
 }
 
 process select_outdated {
-  containerOptions "--contain --workdir $baseDir/work/tmp --bind $baseDir"
+  containerOptions "--contain --workdir $projectDir/work/tmp --bind $projectDir"
   memory '24 GB'
   cpus 4
 
@@ -49,7 +49,7 @@ process select_outdated {
 
 process run_query {
   tag { "$query.baseName" }
-  containerOptions "--contain --workdir $baseDir/work/tmp --bind $baseDir"
+  containerOptions "--contain --workdir $projectDir/work/tmp --bind $projectDir"
 
   input:
   val(_flag)
@@ -65,7 +65,7 @@ process run_query {
 }
 
 process build_table {
-  containerOptions "--contain --workdir $baseDir/work/tmp --bind $baseDir"
+  containerOptions "--contain --workdir $projectDir/work/tmp --bind $projectDir"
   memory '10GB'
 
   input:
@@ -87,7 +87,7 @@ process build_table {
 }
 
 process sort_ids {
-  containerOptions "--contain --workdir $baseDir/work/tmp --bind $baseDir"
+  containerOptions "--contain --workdir $projectDir/work/tmp --bind $projectDir"
 
   input:
   val(_flag)

--- a/workflows/precompute/repeats.nf
+++ b/workflows/precompute/repeats.nf
@@ -58,11 +58,11 @@ process fetch_ensembl_data {
 
 workflow repeats {
   main:
-    Channel.fromPath('files/repeats/find-assemblies.sql') \
-    | combine(Channel.fromPath('config/databases.json')) \
+    channel.fromPath('files/repeats/find-assemblies.sql') \
+    | combine(channel.fromPath('config/databases.json')) \
     | find_genomes_with_repeats \
     | splitCsv \
-    | combine(Channel.fromPath('files/repeats/extract-repeats.sql')) \
+    | combine(channel.fromPath('files/repeats/extract-repeats.sql')) \
     | query_ensembl \
     | fetch_ensembl_data
 

--- a/workflows/precompute/repeats.nf
+++ b/workflows/precompute/repeats.nf
@@ -57,7 +57,6 @@ process fetch_ensembl_data {
 }
 
 workflow repeats {
-  emit: repeats
   main:
     Channel.fromPath('files/repeats/find-assemblies.sql') \
     | combine(Channel.fromPath('config/databases.json')) \
@@ -68,4 +67,5 @@ workflow repeats {
     | fetch_ensembl_data
 
     fetch_ensembl_data.out.repeats | collect | set { repeats }
+  emit: repeats
 }

--- a/workflows/precompute/utils.nf
+++ b/workflows/precompute/utils.nf
@@ -1,6 +1,6 @@
 process query {
   tag { "${query.baseName}" }
-  containerOptions "--contain --workdir $projectDir/work/tmp --bind $projectDir"
+  containerOptions "--contain --workdir $baseDir/work/tmp --bind $baseDir"
 
   input:
   val(max_count)

--- a/workflows/precompute/utils.nf
+++ b/workflows/precompute/utils.nf
@@ -1,6 +1,6 @@
 process query {
   tag { "${query.baseName}" }
-  containerOptions "--contain --workdir $baseDir/work/tmp --bind $baseDir"
+  containerOptions "--contain --workdir $projectDir/work/tmp --bind $projectDir"
 
   input:
   val(max_count)

--- a/workflows/r2dt.nf
+++ b/workflows/r2dt.nf
@@ -21,14 +21,14 @@ process fetch_model_mapping {
 }
 
 process get_partitions {
-  when: { params.r2dt?.run }
-
   input:
   val(_flag)
   path(query)
 
   output:
   path('databases.csv')
+
+  when: { params.r2dt?.run }
 
   script:
   """
@@ -41,13 +41,13 @@ process get_partitions {
 
 
 process fetch_xrefs {
-  when: { params.r2dt?.run }
-
   input:
   tuple val(partition), path(query)
 
   output:
   path('urs_xref.csv')
+
+  when: { params.r2dt?.run }
 
   script:
   """
@@ -60,14 +60,14 @@ process fetch_xrefs {
 }
 
 process fetch_tracked {
-  when: { params.r2dt?.run }
-
   input:
   val(_flag)
   path(query)
 
   output:
   path('urs_tracked.csv')
+
+  when: { params.r2dt?.run }
 
   script:
   """

--- a/workflows/r2dt.nf
+++ b/workflows/r2dt.nf
@@ -215,7 +215,7 @@ process store_secondary_structures {
 workflow common {
   take: ready
   main:
-    Channel.fromPath('files/r2dt/model_mapping.sql') | set { query }
+    channel.fromPath('files/r2dt/model_mapping.sql') | set { query }
 
     fetch_model_mapping(ready, query) | set { mapping }
   emit: mapping
@@ -225,15 +225,15 @@ workflow r2dt {
   take: ready
   main:
     if (params.r2dt.run) {
-      Channel.fromPath("files/r2dt/find-sequences.sql") | set { sequences_sql }
-      Channel.fromPath("files/r2dt/fetch-partition-xref.sql") | set { xref_sql }
-      Channel.fromPath("files/r2dt/fetch-tracked.sql") | set { tracked_sql }
-      Channel.fromPath("files/r2dt/fetch-partitions.sql") | set { partitions_sql }
-      Channel.fromPath('files/r2dt/should-show/model.joblib') | set { ss_model }
-      Channel.fromPath('files/r2dt/should-show/query.sql') | set { ss_query }
-      Channel.fromPath('files/r2dt/should-show/update.ctl') | set { ss_ctl }
-      Channel.fromPath('files/r2dt/load.ctl') | set { load_ctl }
-      Channel.fromPath('files/r2dt/attempted.ctl') | set { attempted_ctl }
+      channel.fromPath("files/r2dt/find-sequences.sql") | set { sequences_sql }
+      channel.fromPath("files/r2dt/fetch-partition-xref.sql") | set { xref_sql }
+      channel.fromPath("files/r2dt/fetch-tracked.sql") | set { tracked_sql }
+      channel.fromPath("files/r2dt/fetch-partitions.sql") | set { partitions_sql }
+      channel.fromPath('files/r2dt/should-show/model.joblib') | set { ss_model }
+      channel.fromPath('files/r2dt/should-show/query.sql') | set { ss_query }
+      channel.fromPath('files/r2dt/should-show/update.ctl') | set { ss_ctl }
+      channel.fromPath('files/r2dt/load.ctl') | set { load_ctl }
+      channel.fromPath('files/r2dt/attempted.ctl') | set { attempted_ctl }
 
       model_info(ready) | set { models_ready }
 
@@ -268,11 +268,11 @@ workflow r2dt {
 
       store_secondary_structures(data, load_ctl, attempted, attempted_ctl, ss_query, ss_model, ss_ctl, uploaded) | set { done }
     } else {
-      Channel.of('r2dt skipped') | set { done }
+      channel.of('r2dt skipped') | set { done }
     }
   emit: done
 }
 
 workflow {
-  r2dt(Channel.from('ready'))
+  r2dt(channel.from('ready'))
 }

--- a/workflows/r2dt.nf
+++ b/workflows/r2dt.nf
@@ -12,7 +12,7 @@ process fetch_model_mapping {
   output:
   path('mapping.json')
 
-  when: { params.r2dt?.run }
+  when: params.r2dt?.run
 
   script:
   """
@@ -28,7 +28,7 @@ process get_partitions {
   output:
   path('databases.csv')
 
-  when: { params.r2dt?.run }
+  when: params.r2dt?.run
 
   script:
   """
@@ -47,7 +47,7 @@ process fetch_xrefs {
   output:
   path('urs_xref.csv')
 
-  when: { params.r2dt?.run }
+  when: params.r2dt?.run
 
   script:
   """
@@ -67,7 +67,7 @@ process fetch_tracked {
   output:
   path('urs_tracked.csv')
 
-  when: { params.r2dt?.run }
+  when: params.r2dt?.run
 
   script:
   """
@@ -90,7 +90,7 @@ process extract_sequences {
   output:
   path('raw.json')
 
-  when: { params.r2dt?.run }
+  when: params.r2dt?.run
 
   script:
   """

--- a/workflows/r2dt/model-info.nf
+++ b/workflows/r2dt/model-info.nf
@@ -9,7 +9,7 @@ process fetch_model_stats {
   path('info.csv'), emit: info
   path '*.tsv', emit: metadata
 
-  when: { params.r2dt?.run }
+  when: params.r2dt?.run
 
   script:
   """

--- a/workflows/r2dt/model-info.nf
+++ b/workflows/r2dt/model-info.nf
@@ -50,7 +50,7 @@ process store_model_info {
 workflow model_info {
   take: ready
   main:
-    Channel.fromPath('files/r2dt/load-models.ctl') | set { load }
+    channel.fromPath('files/r2dt/load-models.ctl') | set { load }
 
     fetch_model_stats(ready)
 
@@ -67,5 +67,5 @@ workflow model_info {
 }
 
 workflow {
-  model_info(Channel.of('ready'))
+  model_info(channel.of('ready'))
 }

--- a/workflows/rfam-scan.nf
+++ b/workflows/rfam-scan.nf
@@ -105,11 +105,11 @@ workflow rfam_scan {
   take: ready
   main:
     if (params.rfam.run) {
-      Channel.fromPath("files/find-active-xrefs-urs.sql").set { active_xref_sql }
-      Channel.fromPath("files/qa/computed.sql").set { computed_sql }
-      Channel.fromPath("files/qa/compute-required.sql").set { compute_required_sql }
-      Channel.fromPath("files/rfam-scan/load.ctl").set { ctl }
-      Channel.fromPath("files/rfam-scan/load-attempted.ctl").set { attempted_ctl }
+      channel.fromPath("files/find-active-xrefs-urs.sql").set { active_xref_sql }
+      channel.fromPath("files/qa/computed.sql").set { computed_sql }
+      channel.fromPath("files/qa/compute-required.sql").set { compute_required_sql }
+      channel.fromPath("files/rfam-scan/load.ctl").set { ctl }
+      channel.fromPath("files/rfam-scan/load-attempted.ctl").set { attempted_ctl }
 
       generate_files(ready)
 
@@ -130,7 +130,7 @@ workflow rfam_scan {
 
       import_data(hits, ctl, attempted, attempted_ctl) | set { done }
     } else {
-      Channel.of('rfam skipped') | set { done }
+      channel.of('rfam skipped') | set { done }
     }
   emit: done
 }

--- a/workflows/rfam-scan.nf
+++ b/workflows/rfam-scan.nf
@@ -1,5 +1,5 @@
 process generate_files {
-  containerOptions "--contain --workdir $projectDir/work/tmp --bind $projectDir"
+  containerOptions "--contain --workdir $baseDir/work/tmp --bind $baseDir"
 
   input:
   val(_flag)
@@ -26,7 +26,7 @@ process generate_files {
 
 process sequences {
   memory '4GB'
-  containerOptions "--contain --workdir $projectDir/work/tmp --bind $projectDir"
+  containerOptions "--contain --workdir $baseDir/work/tmp --bind $baseDir"
   // clusterOptions '-R "rusage[scratch=4000]"'
 
   input:
@@ -37,7 +37,7 @@ process sequences {
 
   script:
   """
-  export TMPDIR="$projectDir/work/tmp"
+  export TMPDIR="$baseDir/work/tmp"
   psql -v ON_ERROR_STOP=1 -f "$active_xrefs" "\$PGDATABASE" | uniq | sort -u > active-urs
   psql -v ON_ERROR_STOP=1 -v 'name=rfam' -f "$computed" "\$PGDATABASE" | sort > computed
   comm -23 active-urs computed > urs-to-compute
@@ -51,7 +51,7 @@ process scan {
   cpus { params.rfam.cpus }
   memory { params.rfam.memory * params.rfam.cpus }
   errorStrategy 'ignore'
-  containerOptions "--contain --workdir $projectDir/work/tmp --bind $projectDir"
+  containerOptions "--contain --workdir $baseDir/work/tmp --bind $baseDir"
 
   input:
   tuple path(version), path('sequences.fasta'), path(cm_files)
@@ -83,7 +83,7 @@ process scan {
 }
 
 process import_data {
-  containerOptions "--contain --workdir $projectDir/work/tmp --bind $projectDir"
+  containerOptions "--contain --workdir $baseDir/work/tmp --bind $baseDir"
   memory 6.GB
   input:
   path('raw*.csv')

--- a/workflows/rfam-scan.nf
+++ b/workflows/rfam-scan.nf
@@ -1,5 +1,5 @@
 process generate_files {
-  containerOptions "--contain --workdir $baseDir/work/tmp --bind $baseDir"
+  containerOptions "--contain --workdir $projectDir/work/tmp --bind $projectDir"
 
   input:
   val(_flag)
@@ -26,7 +26,7 @@ process generate_files {
 
 process sequences {
   memory '4GB'
-  containerOptions "--contain --workdir $baseDir/work/tmp --bind $baseDir"
+  containerOptions "--contain --workdir $projectDir/work/tmp --bind $projectDir"
   // clusterOptions '-R "rusage[scratch=4000]"'
 
   input:
@@ -37,7 +37,7 @@ process sequences {
 
   script:
   """
-  export TMPDIR="$baseDir/work/tmp"
+  export TMPDIR="$projectDir/work/tmp"
   psql -v ON_ERROR_STOP=1 -f "$active_xrefs" "\$PGDATABASE" | uniq | sort -u > active-urs
   psql -v ON_ERROR_STOP=1 -v 'name=rfam' -f "$computed" "\$PGDATABASE" | sort > computed
   comm -23 active-urs computed > urs-to-compute
@@ -51,7 +51,7 @@ process scan {
   cpus { params.rfam.cpus }
   memory { params.rfam.memory * params.rfam.cpus }
   errorStrategy 'ignore'
-  containerOptions "--contain --workdir $baseDir/work/tmp --bind $baseDir"
+  containerOptions "--contain --workdir $projectDir/work/tmp --bind $projectDir"
 
   input:
   tuple path(version), path('sequences.fasta'), path(cm_files)
@@ -83,7 +83,7 @@ process scan {
 }
 
 process import_data {
-  containerOptions "--contain --workdir $baseDir/work/tmp --bind $baseDir"
+  containerOptions "--contain --workdir $projectDir/work/tmp --bind $projectDir"
   memory 6.GB
   input:
   path('raw*.csv')

--- a/workflows/rfam-scan.nf
+++ b/workflows/rfam-scan.nf
@@ -119,9 +119,9 @@ workflow rfam_scan {
       | combine(compute_required_sql) \
       | sequences \
       | flatMap { version, files ->
-        (files instanceof ArrayList) ? files.collect { [version, it] } : [[version, files]]
+        (files instanceof ArrayList) ? files.collect { f -> [version, f] } : [[version, files]]
       } \
-      | filter { v, f -> !f.isEmpty() } \
+      | filter { _v, f -> !f.isEmpty() } \
       | combine(generate_files.out.cm_files) \
       | scan
 

--- a/workflows/rfam-scan.nf
+++ b/workflows/rfam-scan.nf
@@ -8,7 +8,7 @@ process generate_files {
   path 'rfam', emit: cm_files
   path 'version_file', emit: version_info
 
-  when: { params.rfam?.run }
+  when: params.rfam?.run
 
   script:
   def base = params.rfam.files

--- a/workflows/stopfree.nf
+++ b/workflows/stopfree.nf
@@ -91,7 +91,7 @@ workflow stopfree {
     stopfree_scan.out | collect | set { data }
 
     store_results(data, load_ctl)
-    data | map { _v -> 'stopfree done' } | first | set { done }
+    data | map { _v -> 'stopfree done' } | set { done }
     }
   emit: done
 }

--- a/workflows/stopfree.nf
+++ b/workflows/stopfree.nf
@@ -3,13 +3,13 @@
 nextflow.enable.dsl=2
 
 process build_ranges {
-  when: { params.stopfree?.run }
-
   input:
   val(_flag)
 
   output:
   path('ranges.csv')
+
+  when: { params.stopfree?.run }
 
   script:
   def chunk_size = params.stopfree.db_chunk_size

--- a/workflows/stopfree.nf
+++ b/workflows/stopfree.nf
@@ -72,13 +72,13 @@ workflow stopfree {
   take: flag
   main:
     if( !params.stopfree.run ) {
-      Channel.of('stopfree skipped') | set { done }
+      channel.of('stopfree skipped') | set { done }
     } else {
 
     def query = file(params.stopfree.query)
     def load_ctl = file('files/stopfree/stopfree.ctl')
 
-    def fasta_ch = Channel.of('ready') \
+    def fasta_ch = channel.of('ready') \
       | build_ranges \
       | splitCsv \
       | map { _table, min, max -> [min, max, query] } \
@@ -97,5 +97,5 @@ workflow stopfree {
 }
 
 workflow {
-  stopfree(Channel.of('ready'))
+  stopfree(channel.of('ready'))
 }

--- a/workflows/stopfree.nf
+++ b/workflows/stopfree.nf
@@ -69,7 +69,7 @@ process store_results {
 }
 
 workflow stopfree {
-  take: flag
+  take: _flag
   main:
     if( !params.stopfree.run ) {
       channel.of('stopfree skipped') | set { done }

--- a/workflows/stopfree.nf
+++ b/workflows/stopfree.nf
@@ -9,7 +9,7 @@ process build_ranges {
   output:
   path('ranges.csv')
 
-  when: { params.stopfree?.run }
+  when: params.stopfree?.run
 
   script:
   def chunk_size = params.stopfree.db_chunk_size
@@ -27,7 +27,7 @@ process find_sequences {
   output:
   path('sequences/*.fasta'), optional: true
 
-  when: { params.stopfree?.run }
+  when: params.stopfree?.run
 
   script:
   """
@@ -60,7 +60,7 @@ process store_results {
   path('results*.csv')
   path(result_ctl)
 
-  when: { params.stopfree?.load }
+  when: params.stopfree?.load
 
   script:
   """

--- a/workflows/stopfree.nf
+++ b/workflows/stopfree.nf
@@ -91,7 +91,7 @@ workflow stopfree {
     stopfree_scan.out | collect | set { data }
 
     store_results(data, load_ctl)
-    data | map { _ -> 'stopfree done' } | first | set { done }
+    data | map { _v -> 'stopfree done' } | first | set { done }
     }
   emit: done
 }

--- a/workflows/tcode.nf
+++ b/workflows/tcode.nf
@@ -83,13 +83,13 @@ workflow tcode {
   take: flag
   main:
     if( !params.tcode.run ) {
-      Channel.of('tcode skipped') | set { done }
+      channel.of('tcode skipped') | set { done }
     } else {
 
     def query = file(params.tcode.query)
     def load_ctl = file('files/tcode/tcode.ctl')
 
-    def fasta_ch = Channel.of('ready') \
+    def fasta_ch = channel.of('ready') \
       | build_ranges \
       | splitCsv \
       | map { _table, min, max -> [min, max, query] } \
@@ -109,5 +109,5 @@ workflow tcode {
 }
 
 workflow {
-  tcode(Channel.of('ready'))
+  tcode(channel.of('ready'))
 }

--- a/workflows/tcode.nf
+++ b/workflows/tcode.nf
@@ -103,7 +103,7 @@ workflow tcode {
     parse_results.out | collect | set { data }
 
     store_results(data, load_ctl)
-    data | map { _ -> 'tcode done' } | first | set { done }
+    data | map { _v -> 'tcode done' } | first | set { done }
     }
   emit: done
 }

--- a/workflows/tcode.nf
+++ b/workflows/tcode.nf
@@ -103,7 +103,7 @@ workflow tcode {
     parse_results.out | collect | set { data }
 
     store_results(data, load_ctl)
-    data | map { _v -> 'tcode done' } | first | set { done }
+    data | map { _v -> 'tcode done' } | set { done }
     }
   emit: done
 }

--- a/workflows/tcode.nf
+++ b/workflows/tcode.nf
@@ -3,13 +3,13 @@
 nextflow.enable.dsl=2
 
 process build_ranges {
-  when: { params.tcode?.run }
-
   input:
   val(_flag)
 
   output:
   path('ranges.csv')
+
+  when: { params.tcode?.run }
 
   script:
   def chunk_size = params.tcode.db_chunk_size
@@ -19,13 +19,13 @@ process build_ranges {
 }
 
 process find_sequences {
-  when: { params.tcode?.run }
-
   input:
   tuple val(min), val(max), path(query)
 
   output:
   path('sequences/*.fasta'), optional: true
+
+  when: { params.tcode?.run }
 
   script:
   """

--- a/workflows/tcode.nf
+++ b/workflows/tcode.nf
@@ -9,7 +9,7 @@ process build_ranges {
   output:
   path('ranges.csv')
 
-  when: { params.tcode?.run }
+  when: params.tcode?.run
 
   script:
   def chunk_size = params.tcode.db_chunk_size
@@ -25,7 +25,7 @@ process find_sequences {
   output:
   path('sequences/*.fasta'), optional: true
 
-  when: { params.tcode?.run }
+  when: params.tcode?.run
 
   script:
   """
@@ -71,7 +71,7 @@ process store_results {
   path('results*.csv')
   path(result_ctl)
 
-  when: { params.tcode?.load }
+  when: params.tcode?.load
 
   script:
   """

--- a/workflows/tcode.nf
+++ b/workflows/tcode.nf
@@ -80,7 +80,7 @@ process store_results {
 }
 
 workflow tcode {
-  take: flag
+  take: _flag
   main:
     if( !params.tcode.run ) {
       channel.of('tcode skipped') | set { done }

--- a/workflows/utils/slack.nf
+++ b/workflows/utils/slack.nf
@@ -2,7 +2,7 @@ process slack_message {
   input:
   val(message)
 
-  when: { params.get('notify', false) }
+  when: params.get('notify', false)
 
   script:
   params.notify ? """
@@ -15,7 +15,7 @@ process slack_file {
   input:
   path(message)
 
-  when: { params.get('notify', false) }
+  when: params.get('notify', false)
 
   script:
   params.notify ? """

--- a/workflows/utils/slack.nf
+++ b/workflows/utils/slack.nf
@@ -1,8 +1,8 @@
 process slack_message {
-  when: { params.get('notify', false) }
-
   input:
   val(message)
+
+  when: { params.get('notify', false) }
 
   script:
   params.notify ? """
@@ -12,10 +12,10 @@ process slack_message {
 
 
 process slack_file {
-  when: { params.get('notify', false) }
-
   input:
   path(message)
+
+  when: { params.get('notify', false) }
 
   script:
   params.notify ? """

--- a/workflows/utils/slack.nf
+++ b/workflows/utils/slack.nf
@@ -30,22 +30,33 @@ def slack_closure(msg) {
     return
   }
 
-  def configFile = new File("secrets.json");
-  def config = new groovy.json.JsonSlurper().parseFile(configFile, 'UTF-8');
-
-  def post = new URL(config.SLACK_WEBHOOK).openConnection();
-  post.setRequestMethod("POST")
-  post.setDoOutput(true);
-  post.setRequestProperty("Content-Type", "application/json");
-
-  def  payload = "{\"text\" : \"$msg\" }"
-
-
-  post.getOutputStream().write(payload.getBytes("UTF-8"));
-  def postRC = post.getResponseCode();
-  if (postRC != 200) {
-    println("Something went wrong calling slack webhook!");
-    println(post.getInputStream().getText());
+  def configFile = new File("secrets.json")
+  if (!configFile.exists()) {
+    log.warn "Slack notify is enabled but secrets.json was not found; skipping notification"
+    return
   }
 
+  try {
+    def config = new groovy.json.JsonSlurper().parseFile(configFile, 'UTF-8')
+    def webhook = config.SLACK_WEBHOOK
+    if (!webhook) {
+      log.warn "Slack notify is enabled but SLACK_WEBHOOK is missing from secrets.json; skipping notification"
+      return
+    }
+
+    def post = new URL(webhook).openConnection()
+    post.setRequestMethod("POST")
+    post.setDoOutput(true)
+    post.setRequestProperty("Content-Type", "application/json")
+
+    def payload = groovy.json.JsonOutput.toJson([text: msg])
+    post.getOutputStream().write(payload.getBytes("UTF-8"))
+
+    def postRC = post.getResponseCode()
+    if (postRC != 200) {
+      log.warn "Slack webhook returned ${postRC}: ${post.errorStream?.text}"
+    }
+  } catch (Exception e) {
+    log.warn "Could not send Slack notification: ${e}"
+  }
 }


### PR DESCRIPTION
Brings the pipeline up to Nextflow 26.04 (manifest.nextflowVersion = '>=26.04.0'), which enforces strict DSL2 syntax and rejects several constructs the pipeline relied on. 

- Config logic moved out of config files as NF-26 forbids this.
- Fixed some when: guards
- Fix an issue where slack was not reporting correctly.

Ran this on codon for PomBase and it worked correctly.